### PR TITLE
feat(date-format): added more tests cases

### DIFF
--- a/bench/date-format.js
+++ b/bench/date-format.js
@@ -8,7 +8,17 @@ const tableHeader = createTableHeader([
   'samples'
 ])
 
+const twoDigitsLocaleOptions = {
+  year: 'numeric',
+  hour: 'numeric',
+  minute: 'numeric',
+  second: 'numeric',
+  day: '2-digit',
+  month: '2-digit',
+};
+
 const df = new Intl.DateTimeFormat()
+const dfWithOptions = new Intl.DateTimeFormat(undefined, twoDigitsLocaleOptions);
 
 suite.add('Intl.DateTimeFormat().format(Date.now())', function () {
   new Intl.DateTimeFormat().format(Date.now())
@@ -16,8 +26,26 @@ suite.add('Intl.DateTimeFormat().format(Date.now())', function () {
 .add('Intl.DateTimeFormat().format(new Date())', function () {
   new Intl.DateTimeFormat().format(new Date())
 })
+.add('Intl.DateTimeFormat(undefined, twoDigitsLocaleOptions).format(Date.now())', function () {
+  new Intl.DateTimeFormat(undefined, twoDigitsLocaleOptions).format(Date.now())
+})
+.add('Intl.DateTimeFormat(undefined, twoDigitsLocaleOptions).format(new Date())', function () {
+  new Intl.DateTimeFormat(undefined, twoDigitsLocaleOptions).format(new Date())
+})
 .add('Reusing Intl.DateTimeFormat()', function () {
   df.format(Date.now())
+})
+.add('Reusing dfWithOptions.format(Date.now())', function () {
+  dfWithOptions.format(Date.now())
+})
+.add('Reusing dfWithOptions.format(new Date())', function () {
+  dfWithOptions.format(new Date())
+})
+.add('Date.toLocaleDateString()', function () {
+  new Date().toLocaleDateString()
+})
+.add('Date.toLocaleDateString(undefined, twoDigitsLocaleOptions)', function () {
+  new Date().toLocaleDateString(undefined, twoDigitsLocaleOptions);
 })
 .add('Format using date.get*', function() {
   const date = new Date()


### PR DESCRIPTION
I found some performance improvements to https://github.com/nestjs/nest/pull/10823, and one of the improvements I found was that the `toLocaleDateString` function with locale options is much slower than `Intl.DateTimeFormat` passing the same arguments.

So I added the same options I see in NestJS with the comparison to `Intl.DateTimeFormat` creating new instances and reusing the same instance.

I don't know if I'm comparing apple to oranges but I think that worth to know the difference.

Also, for some reason, in that Pull Request I found a difference performance from 1ms to 13ms switching NodeJS version, I tried to isolate the issue but I didn't find any reason that could indicate that NodeJS was the problem, so I think that running inside this tests could bring more light to that problem.