### PR TITLE
feat(date-format): added tests about iso string

### DIFF
--- a/bench/date-format-iso.js
+++ b/bench/date-format-iso.js
@@ -1,0 +1,25 @@
+const Benchmark = require('benchmark')
+const suite = new Benchmark.Suite;
+const { eventToMdTable, H2, createTableHeader } = require('../markdown')
+const { fromUnixToISOString } = require('../utils/from-unix-to-iso-string');
+
+const tableHeader = createTableHeader([
+  'name',
+  'ops/sec',
+  'samples'
+])
+
+suite.add('new Date().toISOString()', function () {
+  new Date().toISOString()
+})
+.add('fromUnixToISOString(new Date())', function () {
+  fromUnixToISOString(new Date())
+})
+.on('cycle', function(event) {
+  console.log(eventToMdTable(event))
+})
+.on('start', function() {
+  console.log(H2('Date toISOString'))
+  console.log(tableHeader)
+})
+.run({ 'async': false });

--- a/bench/date-format.js
+++ b/bench/date-format.js
@@ -1,7 +1,6 @@
 const Benchmark = require('benchmark')
 const suite = new Benchmark.Suite;
 const { eventToMdTable, H2, createTableHeader } = require('../markdown')
-const { fromUnixToISOString } = require('../utils/from-unix-to-iso-string');
 
 const tableHeader = createTableHeader([
   'name',
@@ -11,15 +10,11 @@ const tableHeader = createTableHeader([
 
 const twoDigitsLocaleOptions = {
   year: 'numeric',
-  hour: 'numeric',
-  minute: 'numeric',
-  second: 'numeric',
   day: '2-digit',
   month: '2-digit',
 };
 
 const df = new Intl.DateTimeFormat()
-const dfWithOptions = new Intl.DateTimeFormat(undefined, twoDigitsLocaleOptions);
 
 suite.add('Intl.DateTimeFormat().format(Date.now())', function () {
   new Intl.DateTimeFormat().format(Date.now())
@@ -36,18 +31,6 @@ suite.add('Intl.DateTimeFormat().format(Date.now())', function () {
 .add('Reusing Intl.DateTimeFormat()', function () {
   df.format(Date.now())
 })
-.add('Reusing dfWithOptions.format(Date.now())', function () {
-  dfWithOptions.format(Date.now())
-})
-.add('Reusing dfWithOptions.format(new Date())', function () {
-  dfWithOptions.format(new Date())
-})
-.add('new Date().toISOString()', function () {
-  new Date().toISOString()
-})
-.add('fromUnixToISOString(Date.now())', function () {
-  fromUnixToISOString(Date.now())
-})
 .add('Date.toLocaleDateString()', function () {
   new Date().toLocaleDateString()
 })
@@ -56,13 +39,7 @@ suite.add('Intl.DateTimeFormat().format(Date.now())', function () {
 })
 .add('Format using date.get*', function() {
   const date = new Date()
-  const formated = `${date.getMonth() + 1}/${date.getUTCDate()}/${date.getUTCFullYear()}`
-})
-.add('new Date() (Baseline)', function() {
-  new Date()
-})
-.add('Date.now() (Baseline)', function() {
-  Date.now()
+  `${date.getMonth() + 1}/${date.getUTCDate()}/${date.getUTCFullYear()}`
 })
 .on('cycle', function(event) {
   console.log(eventToMdTable(event))

--- a/bench/date-format.js
+++ b/bench/date-format.js
@@ -1,6 +1,7 @@
 const Benchmark = require('benchmark')
 const suite = new Benchmark.Suite;
 const { eventToMdTable, H2, createTableHeader } = require('../markdown')
+const { fromUnixToISOString } = require('../utils/from-unix-to-iso-string');
 
 const tableHeader = createTableHeader([
   'name',
@@ -40,6 +41,12 @@ suite.add('Intl.DateTimeFormat().format(Date.now())', function () {
 })
 .add('Reusing dfWithOptions.format(new Date())', function () {
   dfWithOptions.format(new Date())
+})
+.add('new Date().toISOString()', function () {
+  new Date().toISOString()
+})
+.add('fromUnixToISOString(Date.now())', function () {
+  fromUnixToISOString(Date.now())
 })
 .add('Date.toLocaleDateString()', function () {
   new Date().toLocaleDateString()

--- a/utils/from-unix-to-iso-string.js
+++ b/utils/from-unix-to-iso-string.js
@@ -1,0 +1,87 @@
+const kMsPerMin = 60 * 1000;
+const kSecPerDay = 24 * 60 * 60;
+const kMsPerDay = kSecPerDay * 1000;
+
+const kMsPerHour = 60 * 60 * 1000;
+
+const kDaysIn4Years = 4 * 365 + 1;
+const kDaysIn100Years = 25 * kDaysIn4Years - 1;
+const kDaysIn400Years = 4 * kDaysIn100Years + 1;
+const kDays1970to2000 = 30 * 365 + 7;
+const kDaysOffset = 1000 * kDaysIn400Years + 5 * kDaysIn400Years - kDays1970to2000;
+const kYearsOffset = 400000;
+const kDaysInMonths = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+const pad = n => (n < 10 ? `0${n}` : n);
+const padMs = n => (n >= 100 ? n : n >= 10 ? `0${n}` : `00${n}`);
+
+function getYearMonthDayFromDays(days) {
+  days += kDaysOffset;
+  let year = 400 * ~~(days / kDaysIn400Years) - kYearsOffset;
+  days %= kDaysIn400Years;
+
+  days--;
+  let yd1 = ~~(days / kDaysIn100Years);
+  days %= kDaysIn100Years;
+  year += 100 * yd1;
+
+  days++;
+  let yd2 = ~~(days / kDaysIn4Years);
+  days %= kDaysIn4Years;
+  year += 4 * yd2;
+
+  days--;
+  let yd3 = ~~(days / 365);
+  days %= 365;
+  year += yd3;
+
+  const is_leap = (!yd1 || yd2) && !yd3;
+
+  days = days + is_leap;
+
+  let month = 0;
+  let day = 0;
+
+  // Check if the date is after February.
+  if (days >= 31 + 28 + (is_leap ? 1 : 0)) {
+    days -= 31 + 28 + (is_leap ? 1 : 0);
+    // Find the date starting from March.
+    for (let i = 2; i < 12; i++) {
+      if (days < kDaysInMonths[i]) {
+        month = i;
+        day = days + 1;
+        break;
+      }
+      days -= kDaysInMonths[i];
+    }
+  } else {
+    // Check January and February.
+    if (days < 31) {
+      month = 0;
+      day = days + 1;
+    } else {
+      month = 1;
+      day = days - 31 + 1;
+    }
+  }
+
+  return `${ year }-${ pad(month + 1) }-${ pad(day) }`;
+}
+
+function fromUnixToISOString(unix) {
+  const days = unix < 0 ? unix - kMsPerDay - 1 : ~~(unix / kMsPerDay);
+  const timeInDayMs = unix - days * kMsPerDay;
+
+  const hour = ~~(timeInDayMs / kMsPerHour);
+  const min = ~~((timeInDayMs / kMsPerMin) % 60);
+  const sec = ~~((timeInDayMs / 1000) % 60);
+  const ms = ~~(timeInDayMs % 1000);
+
+  const datePart = getYearMonthDayFromDays(days);
+
+  return `${datePart}T${pad(hour)}:${pad(min)}:${pad(sec)}.${padMs(ms)}Z`;
+}
+
+module.exports = {
+  fromUnixToISOString, 
+};

--- a/utils/from-unix-to-iso-string.js
+++ b/utils/from-unix-to-iso-string.js
@@ -83,5 +83,5 @@ function fromUnixToISOString(unix) {
 }
 
 module.exports = {
-  fromUnixToISOString, 
+  fromUnixToISOString,
 };


### PR DESCRIPTION
Hey man!

As we talk in twitch, here's the test of adding `new Date().toISOString()` and also `fromUnixToISOString` function to generate ISO String from UNIX time.

I created a folder called `utils` to put the script.

I already run in my fork on NodeJS 19, here's what I got:

## Date format MM/DD/YYYY
  
  |name|ops/sec|samples|
  |-|-|-|
  |Intl.DateTimeFormat().format(Date.now())|7,987|88|
  |Intl.DateTimeFormat().format(new Date())|8,581|79|
  |Intl.DateTimeFormat(undefined, twoDigitsLocaleOptions).format(Date.now())|8,737|92|
  |Intl.DateTimeFormat(undefined, twoDigitsLocaleOptions).format(new Date())|8,623|90|
  |Reusing Intl.DateTimeFormat()|507,988|99|
  |Reusing dfWithOptions.format(Date.now())|292,380|95|
  |Reusing dfWithOptions.format(new Date())|256,879|96|
  |Date.toISOString()|1,005,909|91|
  |fromUnixToISOString(Date.now())|3,5[61](https://github.com/H4ad/nodejs-bench-operations/actions/runs/3905693157/jobs/6673157772#step:4:61),416|94|
  |Date.toLocaleDateString()|524,708|98|
  |Date.toLocaleDateString(undefined, twoDigitsLocaleOptions)|8,[63](https://github.com/H4ad/nodejs-bench-operations/actions/runs/3905693157/jobs/6673157772#step:4:63)3|84|
  |Format using date.get*|3,834,280|98|
  |new Date() (Baseline)|8,510,199|92|
  |Date.now() (Baseline)|15,601,115|95|