### PR TITLE
feat(bench): added property getter access performance

### DIFF
--- a/bench/add-property.js
+++ b/bench/add-property.js
@@ -16,11 +16,6 @@ suite.add('Directly in the object', function () {
   
   data.test = 'Hello';
 })
-.add('Using dot notation with undefined value', function () {
-  const data = { test: undefined }
-  
-  data.test = 'Hello';
-})
 .add('Using define property (writable)', function () {
   const data = { }
   
@@ -31,27 +26,21 @@ suite.add('Directly in the object', function () {
     configurable: true,
   })
 })
+.add('Using define property initialized (writable)', function () {
+  const data = { test: undefined }
+  
+  Object.defineProperty(data, 'test', {
+    value: 'Hello',
+    enumerable: true,
+    configurable: true,
+  });
+})
 .add('Using define property (getter)', function () {
   const data = { }
   
   Object.defineProperty(data, 'test', {
     get() {
       return 'Hello';
-    },
-    enumerable: true,
-    configurable: true,
-  })
-})
-.add('Using define property (getter and setter)', function () {
-  let value = 'Hello';
-  const data = { }
-  
-  Object.defineProperty(data, 'test', {
-    get() {
-      return value;
-    },
-    set(newValue) {
-      value = newValue;
     },
     enumerable: true,
     configurable: true,

--- a/bench/add-property.js
+++ b/bench/add-property.js
@@ -1,0 +1,67 @@
+const Benchmark = require('benchmark')
+const suite = new Benchmark.Suite;
+const { eventToMdTable, H2, createTableHeader } = require('../markdown')
+
+const tableHeader = createTableHeader([
+  'name',
+  'ops/sec',
+  'samples'
+])
+
+suite.add('Directly in the object', function () {
+  const data = { test: 'Hello' }
+})
+.add('Using dot notation', function () {
+  const data = { }
+  
+  data.test = 'Hello';
+})
+.add('Using dot notation with undefined value', function () {
+  const data = { test: undefined }
+  
+  data.test = 'Hello';
+})
+.add('Using define property (writable)', function () {
+  const data = { }
+  
+  Object.defineProperty(data, 'test', {
+    value: 'Hello',
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  })
+})
+.add('Using define property (getter)', function () {
+  const data = { }
+  
+  Object.defineProperty(data, 'test', {
+    get() {
+      return 'Hello';
+    },
+    enumerable: true,
+    configurable: true,
+  })
+})
+.add('Using define property (getter and setter)', function () {
+  let value = 'Hello';
+  const data = { }
+  
+  Object.defineProperty(data, 'test', {
+    get() {
+      return value;
+    },
+    set(newValue) {
+      value = newValue;
+    },
+    enumerable: true,
+    configurable: true,
+  })
+})
+.on('cycle', function(event) {
+  console.log(eventToMdTable(event))
+})
+.on('start', function() {
+  console.log(H2('Adding property'))
+  console.log(tableHeader)
+})
+.run({ 'async': false });

--- a/bench/property-getter-access.js
+++ b/bench/property-getter-access.js
@@ -1,12 +1,16 @@
-const Benchmark = require('benchmark')
-const suite = new Benchmark.Suite;
-const { eventToMdTable, H2, createTableHeader } = require('../markdown')
+const Benchmark = require('benchmark');
+const suite = new Benchmark.Suite();
+const { eventToMdTable, H2, createTableHeader } = require('../markdown');
 
-const tableHeader = createTableHeader([
-  'name',
-  'ops/sec',
-  'samples'
-])
+const tableHeader = createTableHeader(['name', 'ops/sec', 'samples']);
+
+class TestGetter {
+  get test() {
+    return 'Hello';
+  }
+}
+
+const classGetter = new TestGetter();
 
 const getterObj = {
   get test() {
@@ -28,21 +32,137 @@ Object.defineProperty(defineObj, 'test', {
   },
 });
 
+const defineEnumerableFalseObj = {};
+
+Object.defineProperty(defineEnumerableFalseObj, 'test', {
+  get() {
+    return 'Hello';
+  },
+  enumerable: false,
+});
+
+const defineConfigFalseObj = {};
+
+Object.defineProperty(defineConfigFalseObj, 'test', {
+  get() {
+    return 'Hello';
+  },
+  enumerable: true,
+  configurable: false,
+});
+
+const defineEnumerableFalseAndConfigFalseObj = {};
+
+Object.defineProperty(defineEnumerableFalseAndConfigFalseObj, 'test', {
+  get() {
+    return 'Hello';
+  },
+  enumerable: false,
+  configurable: false,
+});
+
+const defineOnlyWritableObj = {};
+
+Object.defineProperty(defineOnlyWritableObj, 'test', {
+  writable: true,
+  value: 'Hello',
+});
+
+const defineWritableEnumerableFalseObj = {};
+
+Object.defineProperty(defineWritableEnumerableFalseObj, 'test', {
+  writable: true,
+  value: 'Hello',
+  enumerable: false,
+});
+
+const defineWritableEnumerableFalseAndConfigFalseObj = {};
+
+Object.defineProperty(defineWritableEnumerableFalseAndConfigFalseObj, 'test', {
+  writable: true,
+  value: 'Hello',
+  enumerable: false,
+  configurable: false,
+});
+
+const definePropertiesObj = {};
+
+Object.defineProperties(definePropertiesObj, {
+  test: {
+    get() {
+      return 'Hello';
+    },
+  },
+});
+
+const definePropertiesEnumerableFalseObj = {};
+
+Object.defineProperties(definePropertiesEnumerableFalseObj, {
+  test: {
+    get() {
+      return 'Hello';
+    },
+    enumerable: false,
+  },
+});
+
+const definePropertiesEnumerableFalseAndConfigFalseObj = {};
+
+Object.defineProperties(definePropertiesEnumerableFalseAndConfigFalseObj, {
+  test: {
+    get() {
+      return 'Hello';
+    },
+    enumerable: false,
+    configurable: false,
+  },
+});
+
 suite
-.add('Getter', function () {
-  const v = getterObj.test;
-})
-.add('Method', function () {
-  const v = methodObj.test();
-})
-.add('DefineProperty', function () {
-  const v = defineObj.test;
-})
-.on('cycle', function(event) {
-  console.log(eventToMdTable(event))
-})
-.on('start', function() {
-  console.log(H2('Property Getter Access'))
-  console.log(tableHeader)
-})
-.run({ 'async': false });
+  .add('Getter (class)', function () {
+    const v = classGetter.test;
+  })
+  .add('Getter', function () {
+    const v = getterObj.test;
+  })
+  .add('Method', function () {
+    const v = methodObj.test();
+  })
+  .add('DefineProperty (getter)', function () {
+    const v = defineObj.test;
+  })
+  .add('DefineProperty (getter & enumerable=false)', function () {
+    const v = defineEnumerableFalseObj.test;
+  })
+  .add('DefineProperty (getter & configurable=false)', function () {
+    const v = defineConfigFalseObj.test;
+  })
+  .add('DefineProperty (getter & enumerable=false & configurable=false)', function () {
+    const v = defineEnumerableFalseAndConfigFalseObj.test;
+  })
+  .add('DefineProperty (writable)', function () {
+    const v = defineOnlyWritableObj.test;
+  })
+  .add('DefineProperty (writable & enumerable=false)', function () {
+    const v = defineWritableEnumerableFalseObj.test;
+  })
+  .add('DefineProperty (writable & enumerable=false & configurable=false)', function () {
+    const v = defineWritableEnumerableFalseAndConfigFalseObj.test;
+  })
+  .add('DefineProperties (getter)', function () {
+    const v = definePropertiesObj.test;
+  })
+  .add('DefineProperties (getter & enumerable=false)', function () {
+    const v = definePropertiesEnumerableFalseObj.test;
+  })
+  .add('DefineProperties (getter & enumerable=false & configurable=false)', function () {
+    const v = definePropertiesEnumerableFalseAndConfigFalseObj.test;
+  })
+  .on('cycle', function (event) {
+    console.log(eventToMdTable(event));
+  })
+  .on('start', function () {
+    console.log(H2('Property Getter Access'));
+    console.log(tableHeader);
+  })
+  .run({ async: false });

--- a/bench/property-getter-access.js
+++ b/bench/property-getter-access.js
@@ -1,0 +1,48 @@
+const Benchmark = require('benchmark')
+const suite = new Benchmark.Suite;
+const { eventToMdTable, H2, createTableHeader } = require('../markdown')
+
+const tableHeader = createTableHeader([
+  'name',
+  'ops/sec',
+  'samples'
+])
+
+const getterObj = {
+  get test() {
+    return 'Hello';
+  },
+};
+
+const methodObj = {
+  test() {
+    return 'Hello';
+  },
+};
+
+const defineObj = {};
+
+Object.defineProperty(defineObj, 'test', {
+  get() {
+    return 'Hello';
+  },
+});
+
+suite
+.add('Getter', function () {
+  const v = getterObj.test;
+})
+.add('Method', function () {
+  const v = methodObj.test();
+})
+.add('DefineProperty', function () {
+  const v = defineObj.test;
+})
+.on('cycle', function(event) {
+  console.log(eventToMdTable(event))
+})
+.on('start', function() {
+  console.log(H2('Property Getter Access'))
+  console.log(tableHeader)
+})
+.run({ 'async': false });

--- a/bench/property-setter-access.js
+++ b/bench/property-setter-access.js
@@ -1,0 +1,52 @@
+const Benchmark = require('benchmark')
+const suite = new Benchmark.Suite;
+const { eventToMdTable, H2, createTableHeader } = require('../markdown')
+
+const tableHeader = createTableHeader([
+  'name',
+  'ops/sec',
+  'samples'
+])
+
+const getterObj = {
+  privateTest: undefined,
+  set test(value) {
+    this.privateTest = value;
+  },
+};
+
+const methodObj = {
+  privateTest: undefined,
+  test(value) {
+    this.privateTest = value;
+  },
+};
+
+const defineObj = {
+  privateTest: undefined,
+};
+
+Object.defineProperty(defineObj, 'test', {
+  set(value) {
+    this.privateTest = value;
+  },
+});
+
+suite
+.add('Setter', function () {
+  getterObj.test = 'Hello';
+})
+.add('Method', function () {
+  methodObj.test('Hello');
+})
+.add('DefineProperty', function () {
+  defineObj.test = 'Hello';
+})
+.on('cycle', function(event) {
+  console.log(eventToMdTable(event))
+})
+.on('start', function() {
+  console.log(H2('Property Setter Access'))
+  console.log(tableHeader)
+})
+.run({ 'async': false });

--- a/bench/property-setter-access.js
+++ b/bench/property-setter-access.js
@@ -8,7 +8,17 @@ const tableHeader = createTableHeader([
   'samples'
 ])
 
-const getterObj = {
+class TestSetter {
+  privateTest = undefined;
+  
+  set test(value) {
+    this.privateTest = value;
+  }
+}
+
+const classSetterObj = new TestSetter();
+
+const setterObj = {
   privateTest: undefined,
   set test(value) {
     this.privateTest = value;
@@ -32,15 +42,142 @@ Object.defineProperty(defineObj, 'test', {
   },
 });
 
+const defineEnumerableFalseObj = {
+  privateTest: undefined,
+};
+
+Object.defineProperty(defineEnumerableFalseObj, 'test', {
+  set(value) {
+    this.privateTest = value;
+  },
+  enumerable: false,
+});
+
+const defineConfigFalseObj = {
+  privateTest: undefined,
+};
+
+Object.defineProperty(defineConfigFalseObj, 'test', {
+  set(value) {
+    this.privateTest = value;
+  },
+  configurable: false,
+});
+
+const defineEnumerableFalseAndConfigFalseObj = {
+  privateTest: undefined,
+};
+
+Object.defineProperty(defineEnumerableFalseAndConfigFalseObj, 'test', {
+  set(value) {
+    this.privateTest = value;
+  },
+  enumerable: false,
+  configurable: false,
+});
+
+const defineOnlyWritableObj = {};
+
+Object.defineProperty(defineOnlyWritableObj, 'test', {
+  writable: true,
+  value: 'Hello',
+});
+
+const defineWritableEnumerableFalseObj = {};
+
+Object.defineProperty(defineWritableEnumerableFalseObj, 'test', {
+  writable: true,
+  value: 'Hello',
+  enumerable: false,
+});
+
+const defineWritableEnumerableFalseAndConfigFalseObj = {};
+
+Object.defineProperty(defineWritableEnumerableFalseAndConfigFalseObj, 'test', {
+  writable: true,
+  value: 'Hello',
+  enumerable: false,
+  configurable: false,
+});
+
+const definePropertiesObj = {
+  private: undefined,
+};
+
+Object.defineProperties(definePropertiesObj, {
+  test: {
+    set(value) {
+      this.privateTest = value;
+    },
+  },
+});
+
+const definePropertiesEnumerableFalseObj = {
+  private: undefined,
+};
+
+Object.defineProperties(definePropertiesEnumerableFalseObj, {
+  test: {
+    set(value) {
+      this.privateTest = value;
+    },
+    enumerable: false,
+  },
+});
+
+const definePropertiesEnumerableFalseAndConfigFalseObj = {
+  private: undefined,
+};
+
+Object.defineProperties(definePropertiesEnumerableFalseAndConfigFalseObj, {
+  test: {
+    set(value) {
+      this.privateTest = value;
+    },
+    enumerable: false,
+    configurable: false,
+  },
+});
+
 suite
+.add('Setter (class)', function () {
+  classSetterObj.test = 'Hello';
+})
 .add('Setter', function () {
-  getterObj.test = 'Hello';
+  setterObj.test = 'Hello';
 })
 .add('Method', function () {
   methodObj.test('Hello');
 })
-.add('DefineProperty', function () {
+.add('DefineProperty (setter)', function () {
   defineObj.test = 'Hello';
+})
+.add('DefineProperty (setter & enumerable=false)', function () {
+  defineEnumerableFalseObj.test = 'Hello';
+})
+.add('DefineProperty (setter & configurable=false)', function () {
+  defineConfigFalseObj.test = 'Hello';
+})
+.add('DefineProperty (setter & enumerable=false & configurable=false)', function () {
+  defineEnumerableFalseAndConfigFalseObj.test = 'Hello';
+})
+.add('DefineProperty (writable)', function () {
+  defineOnlyWritableObj.test = 'Hello';
+})
+.add('DefineProperty (writable & enumerable=false)', function () {
+  defineWritableEnumerableFalseObj.test = 'Hello';
+})
+.add('DefineProperty (writable & enumerable=false & configurable=false)', function () {
+  defineWritableEnumerableFalseAndConfigFalseObj.test = 'Hello';
+})
+.add('DefineProperties (setter)', function () {
+  definePropertiesObj.test = 'Hello';
+})
+.add('DefineProperties (setter & enumerable=false)', function () {
+  definePropertiesEnumerableFalseObj.test = 'Hello';
+})
+.add('DefineProperties (setter & enumerable=false & configurable=false)', function () {
+  definePropertiesEnumerableFalseAndConfigFalseObj.test = 'Hello';
 })
 .on('cycle', function(event) {
   console.log(eventToMdTable(event))


### PR DESCRIPTION
Close #25 

Also, I think that could be worth writing another to check the performance of declaring a field directly in the object and using `defineProperty`, and also, another to check the performance of setting a value with `setter`.