### PR TITLE
feat(bench): added shallow copy benchmark

### DIFF
--- a/bench/shallow-copy.js
+++ b/bench/shallow-copy.js
@@ -1,0 +1,111 @@
+const Benchmark = require('benchmark');
+const suite = new Benchmark.Suite();
+const { eventToMdTable, H2, createTableHeader } = require('../markdown');
+
+const tableHeader = createTableHeader(['name', 'ops/sec', 'samples']);
+
+const headers = {
+  Accept: '*/*',
+  'Accept-Encoding': 'gzip, deflate, br',
+  'Accept-Language': 'en-US,en;q=0.9',
+  'cache-control': 'no-cache',
+  'CloudFront-Forwarded-Proto': 'https',
+  'CloudFront-Is-Desktop-Viewer': 'true',
+  'CloudFront-Is-Mobile-Viewer': 'false',
+  'CloudFront-Is-SmartTV-Viewer': 'false',
+  'CloudFront-Is-Tablet-Viewer': 'false',
+  'CloudFront-Viewer-Country': 'US',
+  'content-type': '',
+  Host: 'xxxxxx.execute-api.us-east-1.amazonaws.com',
+  origin: 'https://xxxxxx.execute-api.us-east-1.amazonaws.com',
+  pragma: 'no-cache',
+  Referer: 'https://xxxxxx.execute-api.us-east-1.amazonaws.com/prod/',
+  'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.131 Safari/537.36',
+  Via: '2.0 00f0a41f749793b9dd653153037c957e.cloudfront.net (CloudFront)',
+  'X-Amz-Cf-Id': '2D5N65SYHJdnJfEmAV_hC0Mw3QvkbUXDumJKAL786IGHRdq_MggPtA==',
+  'X-Amzn-Trace-Id': 'Root=1-5cdf30d0-31a428004abe13807f9445b0',
+  'X-Forwarded-For': '11.111.111.111, 11.111.111.111',
+  'X-Forwarded-Port': '443',
+  'X-Forwarded-Proto': 'https',
+};
+
+suite
+  .add('{ ...object }', () => {
+    const result = { ...headers };
+  })
+  .add('{ ...object, __proto__: null }', () => {
+    const result = { ...headers, __proto__: null };
+  })
+  .add('{ ...object, newProp: true }', () => {
+    const result = { ...headers, newProp: true };
+  })
+  .add('structuredClone', () => {
+    const result = structuredClone(headers);
+  })
+  .add('JSON.parse + JSON.stringify', () => {
+    const result = JSON.parse(JSON.stringify(headers));
+  })
+  .add('loop + object.keys starting with {}', () => {
+    const result = {};
+    const keys = Object.keys(headers);
+
+    for (let i = 0; i < keys.length; i++) {
+      const headerKey = keys[i];
+      result[headerKey] = headers[headerKey];
+    }
+  })
+  .add('loop + object.keys starting with { __proto__: null }', () => {
+    const result = { __proto__: null };
+    const keys = Object.keys(headers);
+
+    for (let i = 0; i < keys.length; i++) {
+      const headerKey = keys[i];
+      result[headerKey] = headers[headerKey];
+    }
+  })
+  .add('loop + object.keys starting with { randomProp: true }', () => {
+    const result = { randomProp: true };
+    const keys = Object.keys(headers);
+
+    for (let i = 0; i < keys.length; i++) {
+      const headerKey = keys[i];
+      result[headerKey] = headers[headerKey];
+    }
+  })
+  .add('object.keys + reduce(FN, {})', () => {
+    const result = Object.keys(headers).reduce((acc, key) => {
+      acc[key] = headers[key];
+
+      return acc;
+    }, {});
+  })
+  .add('object.keys + reduce(FN, { __proto__: null })', () => {
+    const result = Object.keys(headers).reduce(
+      (acc, key) => {
+        acc[key] = headers[key];
+
+        return acc;
+      },
+      { __proto__: null }
+    );
+  })
+  .add('object.keys + reduce(FN, { newProp: true })', () => {
+    const result = Object.keys(headers).reduce(
+      (acc, key) => {
+        acc[key] = headers[key];
+
+        return acc;
+      },
+      { newProp: true }
+    );
+  });
+
+suite
+  .on('cycle', function (event) {
+    console.log(eventToMdTable(event));
+  })
+  .on('start', function () {
+    console.log(H2('Shallow Copy'));
+    console.log(tableHeader);
+  })
+  .run({ async: false });


### PR DESCRIPTION
Closes https://github.com/RafaelGSS/nodejs-bench-operations/issues/34

The only issue with this benchmark is: `structuredClone` is not available on NodeJS 16.x

## Preview

|name|ops/sec|samples|
|-|-|-|
|spread operator|18,210,225|94|
|spread operator (__proto__: null)|18,835,762|91|
|spread operator (randomProp: true)|630,187|79|
|structuredClone|182,811|93|
|JSON.parse + JSON.stringify|146,037|97|
|foreach loop + object.keys|419,626|93|
|foreach loop + object.keys (__proto__: null)|503,733|95|
|foreach loop + object.keys (randomProp: true)|443,399|88|
|for loop + object.keys|406,010|91|
|for loop + object.keys (__proto__: null)|471,934|93|
|for loop + object.keys (randomProp: true)|446,387|94|
|object.keys + reduce|435,705|95|
|object.keys + reduce (__proto__: null)|508,336|96|
|object.keys + reduce (randomProp: true)|440,449|95|

> Runned on NodeJS 20.1.0

I added three variations because I wanna test using `__proto__` to see if we can improve NodeJS getHeaders, and the third variation was because I accidentally mistype `proto` and the performance drop a lot for unknown reason.