### PR TITLE
fix v20 links

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ All the benchmarks are stored in `RESULTS-{Node-Version}.md`
 - [v16](./RESULTS-v16.md)
 - [v18](./RESULTS-v18.md)
 - [v19](./RESULTS-v19.md)
-- [v20](./RESULTS-v19.md)
+- [v20](./RESULTS-v20.md)
 
 It also stores the last 3 versions of each active release line. You can check it inside its respective folder:
 
 - [v16](./v16)
 - [v18](./v18)
 - [v19](./v19)
-- [v20](./v19)
+- [v20](./v20)
 
 This is useful to identify regressions in minor/patch versions.
 


### PR DESCRIPTION
v20 links were referencing v19

I fixed it 🔥 