### PR TITLE
fix(sort-map): sort alphabetically ascending across all benchmarks

### DIFF
--- a/bench/sort-map.js
+++ b/bench/sort-map.js
@@ -20,9 +20,7 @@ suite.add('Sort using default', function () {
   new Map([...map].sort())
 })
 .add('Sort using first char', function () {
-  new Map([...map].sort((a, b) => {
-    return a[0] > b[0] ? -1 : 1
-  }))
+  new Map([...map].sort((a, b) => (a[0] > b[0] ? 1 : -1)))
 })
 .add('Sort using localeCompare', function () {
   new Map([...map].sort((a, b) => String(a[0]).localeCompare(b[0])))


### PR DESCRIPTION
The default sort and `Sort using localeCompare` benchmarks sort alphabetically ascending, however the `Sort using first char` sorts alphabetically descending. Fixed by swapping the two boolean expressions around in the conditional operator.