### PR TITLE
ci: better resilience

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -14,7 +14,12 @@ on:
 
 jobs:
   benchmark:
+    continue-on-error: true
+
     runs-on: ubuntu-latest
+
+    permissions: 
+      issues: write
 
     strategy:
       matrix:
@@ -34,6 +39,21 @@ jobs:
 
       - name: Run Benchmark
         run: node bench/${{ inputs.bench-file }} > ./bench-result.md
+
+      - name: Notify on Error
+        if: ${{ failure() }}
+        uses: dacbd/create-issue-action@main
+        with:
+          token: ${{ github.token }}
+          title: Benchmark ${{ inputs.bench-file }} failed on v${{ matrix.node-version }}
+          body: |
+            ### Context
+            [Failed Run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+            [Codebase](https://github.com/${{ github.repository }}/tree/${{ github.sha }})
+            Workflow name - `${{ github.workflow }}`
+            Job -           `${{ github.job }}`
+            status -        `${{ job.status }}`
+          assignees: RafaelGSS
 
       - name: Append Machine Info to Benchmark Result
         run: node scripts/machine-info.mjs >> ./bench-result.md
@@ -57,6 +77,7 @@ jobs:
   ## Read matrix outputs
   read:
     runs-on: ubuntu-latest
+    if: ${{ !failure() }}
     needs: [benchmark]
 
     steps:
@@ -70,6 +91,7 @@ jobs:
 
   commit:
     runs-on: ubuntu-latest
+    if: ${{ !failure() }}
     needs: [read]
 
     permissions:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,4 +1,4 @@
-name: "Run Benchmark"
+name: 'Run Benchmark'
 
 on:
   workflow_dispatch:
@@ -12,14 +12,14 @@ on:
         required: true
         type: string
 
+permissions:
+  issues: write
+
 jobs:
   benchmark:
     continue-on-error: true
 
     runs-on: ubuntu-latest
-
-    permissions: 
-      issues: write
 
     strategy:
       matrix:
@@ -65,7 +65,7 @@ jobs:
           export RESULT_IN_BASE64=$(cat ./bench-result.md | base64 -w 0)
           echo "BENCH_RESULT=$RESULT_IN_BASE64" >> "$GITHUB_ENV"
 
-      ## Write for matrix outputs workaround 
+      ## Write for matrix outputs workaround
       - uses: cloudposse/github-action-matrix-outputs-write@main
         id: out
         with:
@@ -87,7 +87,7 @@ jobs:
           matrix-step-name: benchmark-${{ inputs.bench-file }}
 
     outputs:
-      result: "${{ steps.read.outputs.result }}"
+      result: '${{ steps.read.outputs.result }}'
 
   commit:
     runs-on: ubuntu-latest

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -55,6 +55,16 @@ jobs:
             status -        `${{ job.status }}`
           assignees: RafaelGSS
 
+      - name: Output Failure
+        if: ${{ failure() }}
+        uses: cloudposse/github-action-matrix-outputs-write@main
+        with:
+          matrix-step-name: benchmark-${{ inputs.bench-file }}
+          matrix-key: ${{ matrix.node-version }}
+          outputs: |-
+            failure: 'true'
+            result: ''
+
       - name: Append Machine Info to Benchmark Result
         run: node scripts/machine-info.mjs >> ./bench-result.md
 
@@ -72,12 +82,12 @@ jobs:
           matrix-step-name: benchmark-${{ inputs.bench-file }}
           matrix-key: ${{ matrix.node-version }}
           outputs: |-
+            failure: 'false'
             result: ${{ env.BENCH_RESULT }}
 
   ## Read matrix outputs
   read:
     runs-on: ubuntu-latest
-    if: ${{ !failure() }}
     needs: [benchmark]
 
     steps:
@@ -91,7 +101,7 @@ jobs:
 
   commit:
     runs-on: ubuntu-latest
-    if: ${{ !failure() }}
+    if: ${{ needs.read.outputs.failure != 'true' }}
     needs: [read]
 
     permissions:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -54,6 +54,7 @@ jobs:
             Job -           `${{ github.job }}`
             status -        `${{ job.status }}`
           assignees: RafaelGSS
+          labels: bug
 
       - name: Output Failure
         if: ${{ failure() }}

--- a/.github/workflows/run_all.yml
+++ b/.github/workflows/run_all.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
 
 jobs:
   

--- a/.github/workflows/watch_bench.yml
+++ b/.github/workflows/watch_bench.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Run Benchmark
         id: benchmark
-        run: node ${{ inputs.bench-file }} > ./bench-result.md
+        run: node ${{ matrix.bench-file }} > ./bench-result.md
 
       - name: Notify on Error
         if: ${{ failure() }}
@@ -73,7 +73,7 @@ jobs:
             Workflow name - `${{ github.workflow }}`
             Job -           `${{ github.job }}`
             status -        `${{ job.status }}`
-          assignees: RafaelGSS
+          assignees: h4ad
 
       - name: Append Machine Info to Benchmark Result
         run: node scripts/machine-info.mjs >> ./bench-result.md

--- a/.github/workflows/watch_bench.yml
+++ b/.github/workflows/watch_bench.yml
@@ -8,12 +8,12 @@ on:
     paths:
       - 'bench/**'
 
+permissions:
+  issues: write
+
 jobs:
   changes:
     runs-on: ubuntu-latest
-
-    permissions: 
-      issues: write    
 
     outputs:
       files: ${{ steps.changes.outputs.benchmarks_files }}

--- a/.github/workflows/watch_bench.yml
+++ b/.github/workflows/watch_bench.yml
@@ -12,6 +12,9 @@ jobs:
   changes:
     runs-on: ubuntu-latest
 
+    permissions: 
+      issues: write    
+
     outputs:
       files: ${{ steps.changes.outputs.benchmarks_files }}
       changes: ${{ steps.changes.outputs.benchmarks }}
@@ -56,6 +59,21 @@ jobs:
       - name: Run Benchmark
         id: benchmark
         run: node ${{ inputs.bench-file }} > ./bench-result.md
+
+      - name: Notify on Error
+        if: ${{ failure() }}
+        uses: dacbd/create-issue-action@main
+        with:
+          token: ${{ github.token }}
+          title: Benchmark ${{ inputs.bench-file }} failed on v${{ matrix.node-version }}
+          body: |
+            ### Context
+            [Failed Run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+            [Codebase](https://github.com/${{ github.repository }}/tree/${{ github.sha }})
+            Workflow name - `${{ github.workflow }}`
+            Job -           `${{ github.job }}`
+            status -        `${{ job.status }}`
+          assignees: RafaelGSS
 
       - name: Append Machine Info to Benchmark Result
         run: node scripts/machine-info.mjs >> ./bench-result.md

--- a/.github/workflows/watch_bench.yml
+++ b/.github/workflows/watch_bench.yml
@@ -73,7 +73,8 @@ jobs:
             Workflow name - `${{ github.workflow }}`
             Job -           `${{ github.job }}`
             status -        `${{ job.status }}`
-          assignees: h4ad
+          assignees: RafaelGSS
+          labels: bug
 
       - name: Append Machine Info to Benchmark Result
         run: node scripts/machine-info.mjs >> ./bench-result.md


### PR DESCRIPTION
What was done:
- Continue the CI when some benchmark fails during `run_all`.
- Fixed issue on watch_bench.yaml that was passing wrong file
- Create an issue when some benchmark fails

Example: https://github.com/h4ad-forks/nodejs-bench-operations/actions/runs/6306816446