### PR TITLE
fix: regression checker pt1

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -126,9 +126,13 @@ jobs:
         with:
           node-version: 20.x
 
+      - name: Create temporary report folder
+        run: mkdir ./temp-reports
+
       - uses: actions/download-artifact@v3
         with:
           name: benchmark-artifacts-${{github.run_id}}
+          path: ./temp-reports
 
       - name: Write Benchmark Reports
         run: |
@@ -137,6 +141,9 @@ jobs:
         env:
           BENCH_FILE: ${{ inputs.bench-file }}
           BENCH_ARTIFACTS: ${{ needs.read.outputs.result }}
+
+      - name: Clean temporary report folder
+        run: rm -r ./temp-reports
 
       - name: Commit and Push Updated Results
         uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -38,7 +38,7 @@ jobs:
         run: npm install
 
       - name: Report Filename
-        run: echo "BENCH_REPORT_FILE=report-${{github.run_id}}-${{ matrix.node-version }}-${{ inputs.bench-file }}.md" >> $GITHUB_STEP_SUMMARY
+        run: echo "BENCH_REPORT_FILE=report-${{github.run_id}}-${{ matrix.node-version }}-${{ inputs.bench-file }}.md" >> $GITHUB_ENV
 
       - name: Run Benchmark
         run: node bench/${{ inputs.bench-file }} > ./${{ env.BENCH_REPORT_FILE }}.md

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Add Job Summary
         run: |
-          result=$(cat ./${{ env.BENCH_REPORT_FILE }}
+          result=$(cat ./${{ env.BENCH_REPORT_FILE }})
           echo "$result" >> $GITHUB_STEP_SUMMARY
 
       - name: Upload Bench Result

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -37,8 +37,11 @@ jobs:
       - name: NPM Install
         run: npm install
 
+      - name: Report Filename
+        run: echo "BENCH_REPORT_FILE=report-${{github.run_id}}-${{ matrix.node-version }}-${{ inputs.bench-file }}.md" >> $GITHUB_STEP_SUMMARY
+
       - name: Run Benchmark
-        run: node bench/${{ inputs.bench-file }} > ./bench-result.md
+        run: node bench/${{ inputs.bench-file }} > ./${{ env.BENCH_REPORT_FILE }}.md
         env:
           CI: true
 
@@ -70,16 +73,16 @@ jobs:
 
       - name: Add Job Summary
         run: |
-          result=$(cat ./bench-result.md)
+          result=$(cat ./${{ env.BENCH_REPORT_FILE }}
           echo "$result" >> $GITHUB_STEP_SUMMARY
 
       - name: Upload Bench Result
         uses: actions/upload-artifact@v3
         with:
-          name: benchmark-${{github.run_id}}-${{ matrix.node-version }}-${{ inputs.bench-file }}.md
+          name: benchmark-artifacts-${{github.run_id}}
           retention-days: 1
           if-no-files-found: error
-          path: ./bench-result.md
+          path: ./${{ env.BENCH_REPORT_FILE }}
 
       ## Write for matrix outputs workaround
       - uses: cloudposse/github-action-matrix-outputs-write@main
@@ -89,7 +92,7 @@ jobs:
           matrix-key: ${{ matrix.node-version }}
           outputs: |-
             failure: 'false'
-            result: benchmark-${{github.run_id}}-${{ matrix.node-version }}-${{ inputs.bench-file }}.md
+            result: ${{ env.BENCH_REPORT_FILE }}
 
   ## Read matrix outputs
   read:
@@ -123,9 +126,10 @@ jobs:
         with:
           node-version: 20.x
 
-      - name: NPM Install
-        run: npm install
-  
+      - uses: actions/download-artifact@v3
+        with:
+          name: benchmark-artifacts-${{github.run_id}}
+
       - name: Write Benchmark Reports
         run: |
           node scripts/write-bench-results.mjs

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Install
+      - name: NPM Install
         run: npm install
 
       - name: Run Benchmark
@@ -68,12 +68,18 @@ jobs:
             failure: 'true'
             result: ''
 
-      - name: Set Env Variable
+      - name: Add Job Summary
         run: |
           result=$(cat ./bench-result.md)
           echo "$result" >> $GITHUB_STEP_SUMMARY
-          export RESULT_IN_BASE64=$(cat ./bench-result.md | base64 -w 0)
-          echo "BENCH_RESULT=$RESULT_IN_BASE64" >> "$GITHUB_ENV"
+
+      - name: Upload Bench Result
+        uses: actions/upload-artifact@v3
+        with:
+          name: benchmark-${{github.run_id}}-${{ matrix.node-version }}-${{ inputs.bench-file }}.md
+          retention-days: 1
+          if-no-files-found: error
+          path: ./bench-result.md
 
       ## Write for matrix outputs workaround
       - uses: cloudposse/github-action-matrix-outputs-write@main
@@ -83,7 +89,7 @@ jobs:
           matrix-key: ${{ matrix.node-version }}
           outputs: |-
             failure: 'false'
-            result: ${{ env.BENCH_RESULT }}
+            result: benchmark-${{github.run_id}}-${{ matrix.node-version }}-${{ inputs.bench-file }}.md
 
   ## Read matrix outputs
   read:
@@ -117,13 +123,16 @@ jobs:
         with:
           node-version: 20.x
 
+      - name: NPM Install
+        run: npm install
+  
       - name: Write Benchmark Reports
         run: |
           node scripts/write-bench-results.mjs
           node scripts/generate-reports.mjs
         env:
           BENCH_FILE: ${{ inputs.bench-file }}
-          BENCH_RESULT: ${{ needs.read.outputs.result }}
+          BENCH_ARTIFACTS: ${{ needs.read.outputs.result }}
 
       - name: Commit and Push Updated Results
         uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -41,7 +41,7 @@ jobs:
         run: echo "BENCH_REPORT_FILE=report-${{github.run_id}}-${{ matrix.node-version }}-${{ inputs.bench-file }}.md" >> $GITHUB_ENV
 
       - name: Run Benchmark
-        run: node bench/${{ inputs.bench-file }} > ./${{ env.BENCH_REPORT_FILE }}.md
+        run: node bench/${{ inputs.bench-file }} > ./${{ env.BENCH_REPORT_FILE }}
         env:
           CI: true
 

--- a/.github/workflows/watch_bench.yml
+++ b/.github/workflows/watch_bench.yml
@@ -134,9 +134,13 @@ jobs:
         with:
           node-version: 20.x
 
+      - name: Create temporary report folder
+        run: mkdir ./temp-reports
+
       - uses: actions/download-artifact@v3
         with:
           name: benchmark-artifacts-${{github.run_id}}
+          path: ./temp-reports
 
       - name: Write Benchmark Results
         run: |
@@ -144,6 +148,9 @@ jobs:
           node scripts/generate-reports.mjs
         env:
           BENCH_RESULT: ${{ needs.read.outputs.result }}
+
+      - name: Clean temporary report folder
+        run: rm -r ./temp-reports
 
       - name: Commit and Push Updated Results
         uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/watch_bench.yml
+++ b/.github/workflows/watch_bench.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Add Job Summary
         run: |
-          result=$(cat ./${{ env.BENCH_REPORT_FILE }}
+          result=$(cat ./${{ env.BENCH_REPORT_FILE }})
           echo "$result" >> $GITHUB_STEP_SUMMARY
 
       - name: Upload Bench Result

--- a/.github/workflows/watch_bench.yml
+++ b/.github/workflows/watch_bench.yml
@@ -52,13 +52,16 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: NPM Install
-        run: |
-          npm install
+      - name: Correct Bench file
+        run: |-
+          export SAFE_BENCH_FILE=$(basename ${{ matrix.bench-file }})
+          echo "BENCH_FILE=$SAFE_BENCH_FILE" >> "$GITHUB_ENV"
+
+      - name: Report Filename
+        run: echo "BENCH_REPORT_FILE=report-${{github.run_id}}-${{ matrix.node-version }}-${{ env.BENCH_FILE }}.md" >> $GITHUB_STEP_SUMMARY
 
       - name: Run Benchmark
-        id: benchmark
-        run: node ${{ matrix.bench-file }} > ./bench-result.md
+        run: node bench/${{ env.BENCH_FILE }} > ./${{ env.BENCH_REPORT_FILE }}.md
         env:
           CI: true
 
@@ -67,7 +70,7 @@ jobs:
         uses: dacbd/create-issue-action@main
         with:
           token: ${{ github.token }}
-          title: Benchmark ${{ matrix.bench-file }} failed on v${{ matrix.node-version }}
+          title: Benchmark ${{ env.BENCH_FILE }} failed on v${{ matrix.node-version }}
           body: |
             ### Context
             [Failed Run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
@@ -80,18 +83,16 @@ jobs:
 
       - name: Add Job Summary
         run: |
-          result=$(cat ./bench-result.md)
+          result=$(cat ./${{ env.BENCH_REPORT_FILE }}
           echo "$result" >> $GITHUB_STEP_SUMMARY
-          export SAFE_BENCH_FILE=$(basename ${{ matrix.bench-file }})
-          echo "BENCH_FILE=$SAFE_BENCH_FILE" >> "$GITHUB_ENV"
 
       - name: Upload Bench Result
         uses: actions/upload-artifact@v3
         with:
-          name: benchmark-${{github.run_id}}-${{ matrix.node-version }}-${{ env.BENCH_FILE }}.md
+          name: benchmark-artifacts-${{github.run_id}}
           retention-days: 1
           if-no-files-found: error
-          path: ./bench-result.md
+          path: ./${{ env.BENCH_REPORT_FILE }}
 
       ## Write for matrix outputs workaround
       - uses: cloudposse/github-action-matrix-outputs-write@main
@@ -100,7 +101,7 @@ jobs:
           matrix-step-name: benchmark
           matrix-key: ${{ env.BENCH_FILE }}:${{ matrix.node-version }}
           outputs: |-
-            result: benchmark-${{github.run_id}}-${{ matrix.node-version }}-${{ env.BENCH_FILE }}.md
+            result: ${{ env.BENCH_REPORT_FILE }}
 
   ## Read matrix outputs
   read:
@@ -133,8 +134,9 @@ jobs:
         with:
           node-version: 20.x
 
-      - name: NPM Install
-        run: npm install
+      - uses: actions/download-artifact@v3
+        with:
+          name: benchmark-artifacts-${{github.run_id}}
 
       - name: Write Benchmark Results
         run: |

--- a/.github/workflows/watch_bench.yml
+++ b/.github/workflows/watch_bench.yml
@@ -61,7 +61,7 @@ jobs:
         run: echo "BENCH_REPORT_FILE=report-${{github.run_id}}-${{ matrix.node-version }}-${{ env.BENCH_FILE }}.md" >> $GITHUB_ENV
 
       - name: Run Benchmark
-        run: node bench/${{ env.BENCH_FILE }} > ./${{ env.BENCH_REPORT_FILE }}.md
+        run: node bench/${{ env.BENCH_FILE }} > ./${{ env.BENCH_REPORT_FILE }}
         env:
           CI: true
 

--- a/.github/workflows/watch_bench.yml
+++ b/.github/workflows/watch_bench.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Install
+      - name: NPM Install
         run: |
           npm install
 
@@ -67,7 +67,7 @@ jobs:
         uses: dacbd/create-issue-action@main
         with:
           token: ${{ github.token }}
-          title: Benchmark ${{ inputs.bench-file }} failed on v${{ matrix.node-version }}
+          title: Benchmark ${{ matrix.bench-file }} failed on v${{ matrix.node-version }}
           body: |
             ### Context
             [Failed Run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
@@ -78,21 +78,29 @@ jobs:
           assignees: RafaelGSS
           labels: bug
 
-      - name: Set Env Variable
+      - name: Add Job Summary
         run: |
           result=$(cat ./bench-result.md)
           echo "$result" >> $GITHUB_STEP_SUMMARY
-          export RESULT_IN_BASE64=$(cat ./bench-result.md | base64 -w 0)
-          echo "BENCH_RESULT=$RESULT_IN_BASE64" >> "$GITHUB_ENV"
+          export SAFE_BENCH_FILE=$(basename ${{ matrix.bench-file }})
+          echo "BENCH_FILE=$SAFE_BENCH_FILE" >> "$GITHUB_ENV"
+
+      - name: Upload Bench Result
+        uses: actions/upload-artifact@v3
+        with:
+          name: benchmark-${{github.run_id}}-${{ matrix.node-version }}-${{ env.BENCH_FILE }}.md
+          retention-days: 1
+          if-no-files-found: error
+          path: ./bench-result.md
 
       ## Write for matrix outputs workaround
       - uses: cloudposse/github-action-matrix-outputs-write@main
         id: out
         with:
           matrix-step-name: benchmark
-          matrix-key: ${{ matrix.bench-file }}:${{ matrix.node-version }}
+          matrix-key: ${{ env.BENCH_FILE }}:${{ matrix.node-version }}
           outputs: |-
-            result: ${{ env.BENCH_RESULT }}
+            result: benchmark-${{github.run_id}}-${{ matrix.node-version }}-${{ env.BENCH_FILE }}.md
 
   ## Read matrix outputs
   read:
@@ -124,6 +132,9 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 20.x
+
+      - name: NPM Install
+        run: npm install
 
       - name: Write Benchmark Results
         run: |

--- a/.github/workflows/watch_bench.yml
+++ b/.github/workflows/watch_bench.yml
@@ -52,6 +52,9 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      - name: NPM Install
+        run: npm install
+  
       - name: Correct Bench file
         run: |-
           export SAFE_BENCH_FILE=$(basename ${{ matrix.bench-file }})

--- a/.github/workflows/watch_bench.yml
+++ b/.github/workflows/watch_bench.yml
@@ -150,7 +150,7 @@ jobs:
           node scripts/write-bench-results.mjs
           node scripts/generate-reports.mjs
         env:
-          BENCH_RESULT: ${{ needs.read.outputs.result }}
+          BENCH_ARTIFACTS: ${{ needs.read.outputs.result }}
 
       - name: Clean temporary report folder
         run: rm -r ./temp-reports

--- a/.github/workflows/watch_bench.yml
+++ b/.github/workflows/watch_bench.yml
@@ -58,7 +58,7 @@ jobs:
           echo "BENCH_FILE=$SAFE_BENCH_FILE" >> "$GITHUB_ENV"
 
       - name: Report Filename
-        run: echo "BENCH_REPORT_FILE=report-${{github.run_id}}-${{ matrix.node-version }}-${{ env.BENCH_FILE }}.md" >> $GITHUB_STEP_SUMMARY
+        run: echo "BENCH_REPORT_FILE=report-${{github.run_id}}-${{ matrix.node-version }}-${{ env.BENCH_FILE }}.md" >> $GITHUB_ENV
 
       - name: Run Benchmark
         run: node bench/${{ env.BENCH_FILE }} > ./${{ env.BENCH_REPORT_FILE }}.md

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Is X faster than Y in Node.js vX.Z?",
   "main": "bin.js",
   "dependencies": {
+    "@actions/artifact": "^1.1.2",
     "autocannon": "^7.7.1",
     "benchmark": "^2.1.4",
     "fastify": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Is X faster than Y in Node.js vX.Z?",
   "main": "bin.js",
   "dependencies": {
-    "@actions/artifact": "^1.1.2",
     "autocannon": "^7.7.1",
     "benchmark": "^2.1.4",
     "fastify": "^4.4.0",

--- a/scripts/write-bench-results.mjs
+++ b/scripts/write-bench-results.mjs
@@ -1,8 +1,6 @@
-import { mkdir, writeFile, rename } from 'node:fs/promises';
+import { mkdir, rename } from 'node:fs/promises';
 import { basename, resolve } from 'node:path';
 import { existAsync, rootFolder } from './utils.mjs';
-import { create as createArtifactClient } from '@actions/artifact';
-import { readFileSync } from 'node:fs';
 
 /**
  * The object result with the artifacts names
@@ -10,16 +8,14 @@ import { readFileSync } from 'node:fs';
  * 
  * ```js
  * // when is called by bench.yml
- * { '18.18.0': 'benchmark-1-18.18.0-add-property.js.md' }
+ * { '18.18.0': 'result-1-18.18.0-add-property.js.md' }
  * // when is called by watch_bench.yml
- * { 'add-property.js:18.18.0': 'benchmark-1-18.18.0-add-property.js.md' }
+ * { 'add-property.js:18.18.0': 'result-1-18.18.0-add-property.js.md' }
  * ```
  * 
  * @type {{ result: { [nodeVersion: string]: string } }}
  */
 const benchResult = JSON.parse(process.env.BENCH_ARTIFACTS);
-
-const artifactClient = createArtifactClient();
 
 function getBenchmarkFile(key) {
   const filepath = process.env.BENCH_FILE || key.split(':')[0];
@@ -36,9 +32,8 @@ for (const key of Object.keys(benchResult.result)) {
   const nodeVersion = getBenchmarkNodeVersion(key).replace(/\./g, '_');
 
   const major = nodeVersion.split('_')[0];
-  const artifactKey = benchResult.result[key];
+  const reportFilepath = benchResult.result[key];
 
-  const { downloadPath } = await artifactClient.downloadArtifact(artifactKey, `./${ artifactKey }`);
   const outputFolder = resolve(rootFolder, `./v${major}/v${nodeVersion}`);
 
   const outputFolderExist = await existAsync(outputFolder);
@@ -49,5 +44,5 @@ for (const key of Object.keys(benchResult.result)) {
     });
   }
 
-  await rename(downloadPath, `${outputFolder}/${benchFile}.md`, 'utf-8');
+  await rename(`./${reportFilepath}`, `${outputFolder}/${benchFile}.md`, 'utf-8');
 }

--- a/scripts/write-bench-results.mjs
+++ b/scripts/write-bench-results.mjs
@@ -1,4 +1,4 @@
-import { mkdir, rename } from 'node:fs/promises';
+import { mkdir, readdir, rename, rm } from 'node:fs/promises';
 import { basename, resolve } from 'node:path';
 import { existAsync, rootFolder } from './utils.mjs';
 
@@ -44,5 +44,5 @@ for (const key of Object.keys(benchResult.result)) {
     });
   }
 
-  await rename(`./${reportFilepath}`, `${outputFolder}/${benchFile}.md`, 'utf-8');
+  await rename(`./temp-reports/${reportFilepath}`, `${outputFolder}/${benchFile}.md`, 'utf-8');
 }

--- a/scripts/write-bench-results.mjs
+++ b/scripts/write-bench-results.mjs
@@ -1,8 +1,25 @@
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdir, writeFile, rename } from 'node:fs/promises';
 import { basename, resolve } from 'node:path';
 import { existAsync, rootFolder } from './utils.mjs';
+import { create as createArtifactClient } from '@actions/artifact';
+import { readFileSync } from 'node:fs';
 
-const benchResult = JSON.parse(process.env.BENCH_RESULT);
+/**
+ * The object result with the artifacts names
+ * The result will be a record with the possible states:
+ * 
+ * ```js
+ * // when is called by bench.yml
+ * { '18.18.0': 'benchmark-1-18.18.0-add-property.js.md' }
+ * // when is called by watch_bench.yml
+ * { 'add-property.js:18.18.0': 'benchmark-1-18.18.0-add-property.js.md' }
+ * ```
+ * 
+ * @type {{ result: { [nodeVersion: string]: string } }}
+ */
+const benchResult = JSON.parse(process.env.BENCH_ARTIFACTS);
+
+const artifactClient = createArtifactClient();
 
 function getBenchmarkFile(key) {
   const filepath = process.env.BENCH_FILE || key.split(':')[0];
@@ -19,7 +36,9 @@ for (const key of Object.keys(benchResult.result)) {
   const nodeVersion = getBenchmarkNodeVersion(key).replace(/\./g, '_');
 
   const major = nodeVersion.split('_')[0];
-  const result = Buffer.from(benchResult.result[key], 'base64').toString('utf8');
+  const artifactKey = benchResult.result[key];
+
+  const { downloadPath } = await artifactClient.downloadArtifact(artifactKey, `./${ artifactKey }`);
   const outputFolder = resolve(rootFolder, `./v${major}/v${nodeVersion}`);
 
   const outputFolderExist = await existAsync(outputFolder);
@@ -30,5 +49,5 @@ for (const key of Object.keys(benchResult.result)) {
     });
   }
 
-  await writeFile(`${outputFolder}/${benchFile}.md`, result, 'utf-8');
+  await rename(downloadPath, `${outputFolder}/${benchFile}.md`, 'utf-8');
 }


### PR DESCRIPTION
Instead of storing the files on output, I now upload them to the artifacts and then download the file later.

But I still use the `outputs` to store the files that I generated on each benchmark.

Closes #52