### PR TITLE
refactor(deleting-properties): added more benchmarks

### DIFF
--- a/bench/deleting-properties.js
+++ b/bench/deleting-properties.js
@@ -5,14 +5,6 @@ const suite = createBenchmarkSuite('Deleting properties')
 const NullObject = function NullObject () { }
 NullObject.prototype = Object.create(null)
 
-const setupForMap = function () {
-  const data = new Map();
-  
-  for (let i = 0; i < this.count; i++) {
-    data.set(i.toString(), i);
-  }
-}
-
 suite
   .add('Using delete property', function () {
     const data = { x: 1, y: 2, z: 3 }
@@ -42,11 +34,6 @@ suite
     data.x
     data.y
     data.z
-  })
-  .add('Using map.delete', function () {
-    data.delete(this.count.toString())
-  }, {
-    setup: setupForMap,
   })
   .add('Using undefined assignment', function () {
     const data = { x: 1, y: 2, z: 3 }

--- a/bench/deleting-properties.js
+++ b/bench/deleting-properties.js
@@ -2,6 +2,17 @@ const { createBenchmarkSuite } = require('../common')
 
 const suite = createBenchmarkSuite('Deleting properties')
 
+const NullObject = function NullObject () { }
+NullObject.prototype = Object.create(null)
+
+const setupForMap = function () {
+  const data = new Map();
+  
+  for (let i = 0; i < this.count; i++) {
+    data.set(i.toString(), i);
+  }
+}
+
 suite
   .add('Using delete property', function () {
     const data = { x: 1, y: 2, z: 3 }
@@ -11,8 +22,55 @@ suite
     data.y
     data.z
   })
+  .add('Using delete property (proto: null)', function () {
+    const data = { __proto__: null, x: 1, y: 2, z: 3 }
+    delete data.y
+
+    data.x
+    data.y
+    data.z
+  })
+  .add('Using delete property (cached proto: null)', function () {
+    const data = new NullObject()
+
+    data.x = 1
+    data.y = 2
+    data.z = 3
+
+    delete data.y
+
+    data.x
+    data.y
+    data.z
+  })
+  .add('Using map.delete', function () {
+    data.delete(this.count.toString())
+  }, {
+    setup: setupForMap,
+  })
   .add('Using undefined assignment', function () {
     const data = { x: 1, y: 2, z: 3 }
+    data.y = undefined
+
+    data.x
+    data.y
+    data.z
+  })
+  .add('Using undefined assignment (proto: null)', function () {
+    const data = { __proto__: null, x: 1, y: 2, z: 3 }
+    data.y = undefined
+
+    data.x
+    data.y
+    data.z
+  })
+  .add('Using undefined property (cached proto: null)', function () {
+    const data = new NullObject()
+
+    data.x = 1
+    data.y = 2
+    data.z = 3
+
     data.y = undefined
 
     data.x


### PR DESCRIPTION
An interesting case where deleting properties from an `object` is faster when the object is created with `proto null`.

|name|ops/sec|samples|
|-|-|-|
|Using delete property|5,592,197|96|
|Using delete property (proto: null)|31,741,791|98|
|Using delete property (cached proto: null)|5,708,858|96|
|Using map.delete|91,356,105|10|
|Using undefined assignment|1,229,023,353|100|
|Using undefined assignment (proto: null)|33,922,525|98|
|Using undefined property (cached proto: null)|1,230,397,935|95|

About `map.delete`, I don't the comparison is fair enough since we are creating objects in every benchmark but it was the only way that I found to test only the `delete`.

Let me know what you think.

