### PR TITLE
lib: replace benchmarkjs with tinybench

### DIFF
--- a/bench/add-property.mjs
+++ b/bench/add-property.mjs
@@ -41,4 +41,5 @@ suite
       configurable: true,
     })
   })
-  .run({ async: false })
+
+await suite.runAndPrintResults()

--- a/bench/array-creation.mjs
+++ b/bench/array-creation.mjs
@@ -9,4 +9,5 @@ suite
   .add('Array.from', function () {
     Array.from({ length: 1024 * 1024 })
   })
-  .run({ async: false })
+
+await suite.runAndPrintResults()

--- a/bench/async-function-vs-function.mjs
+++ b/bench/async-function-vs-function.mjs
@@ -33,4 +33,5 @@ suite
     },
     defer: true,
   })
-  .run({ async: false });
+  
+await suite.runAndPrintResults()

--- a/bench/blob.mjs
+++ b/bench/blob.mjs
@@ -56,4 +56,5 @@ suite
   .add('slice (0, 512)', function (deferred) {
     blob1024.slice(0, 512)
   })
-  .run({ async: false })
+
+await suite.runAndPrintResults()

--- a/bench/compare-using-instanceof.mjs
+++ b/bench/compare-using-instanceof.mjs
@@ -39,4 +39,5 @@ suite
       1 + 1
     }
   })
-  .run({ async: false })
+
+await suite.runAndPrintResults()

--- a/bench/crypto-verify.mjs
+++ b/bench/crypto-verify.mjs
@@ -58,4 +58,5 @@ suite
   .add(`crypto.verify('${algorithm}')`, function () {
     verify(algorithm, thing, rsaPublicKey, Buffer.from(signature, 'base64'))
   })
-  .run({ async: false })
+
+await suite.runAndPrintResults()

--- a/bench/date-format-iso.mjs
+++ b/bench/date-format-iso.mjs
@@ -10,4 +10,5 @@ suite
   .add('fromUnixToISOString(new Date())', function () {
     fromUnixToISOString(new Date())
   })
-  .run({ async: false })
+
+await suite.runAndPrintResults()

--- a/bench/date-format.mjs
+++ b/bench/date-format.mjs
@@ -35,4 +35,5 @@ suite
   .add('Format using date.get*', function () {
     const date = new Date()`${date.getMonth() + 1}/${date.getUTCDate()}/${date.getUTCFullYear()}`
   })
-  .run({ async: false })
+
+await suite.runAndPrintResults()

--- a/bench/date-string-coersion.mjs
+++ b/bench/date-string-coersion.mjs
@@ -19,4 +19,5 @@ suite
     const date = new Date()
     const value = date.toString()
   })
-  .run({ async: false })
+
+await suite.runAndPrintResults()

--- a/bench/deleting-properties.mjs
+++ b/bench/deleting-properties.mjs
@@ -64,4 +64,5 @@ suite
     data.y
     data.z
   })
-  .run({ async: false })
+
+await suite.runAndPrintResults()

--- a/bench/error.mjs
+++ b/bench/error.mjs
@@ -12,4 +12,5 @@ suite
   .add('NodeError Range', function () {
     new RangeError('test')
   })
-  .run({ async: false })
+
+await suite.runAndPrintResults()

--- a/bench/function-return.mjs
+++ b/bench/function-return.mjs
@@ -43,4 +43,5 @@ suite
     const test = new Function('test', 'return []')
     const a = test()
   })
-  .run({ async: false })
+
+await suite.runAndPrintResults()

--- a/bench/includes-vs-raw-comparison.mjs
+++ b/bench/includes-vs-raw-comparison.mjs
@@ -19,4 +19,5 @@ suite
     const httpVersion = '2.0'
     const exists = httpVersion === '2.0' || httpVersion === '1.0' || httpVersion === '1.1'
   })
-  .run({ async: false })
+
+await suite.runAndPrintResults()

--- a/bench/keys-vs-getownpropertynames.mjs
+++ b/bench/keys-vs-getownpropertynames.mjs
@@ -19,4 +19,5 @@ suite
     }
     const keys = Object.getOwnPropertyNames(object)
   })
-  .run({ async: false })
+
+await suite.runAndPrintResults()

--- a/bench/last-array-item.mjs
+++ b/bench/last-array-item.mjs
@@ -25,4 +25,5 @@ suite
   .add('Length = 1_000_000 - Array[length - 1]', function () {
     arr100_000_0[arr100_000_0.length - 1]
   })
-  .run({ async: false })
+
+await suite.runAndPrintResults()

--- a/bench/object-creation.mjs
+++ b/bench/object-creation.mjs
@@ -24,4 +24,5 @@ suite
     function C() {}
     new C()
   })
-  .run({ async: false })
+
+await suite.runAndPrintResults()

--- a/bench/optional-chain-vs-and-operator.mjs
+++ b/bench/optional-chain-vs-and-operator.mjs
@@ -27,4 +27,5 @@ suite
   .add('Using and operator (obj.field && obj.field.field2) (undefined)', function () {
     nullObj.field && nullObj.field.field2
   })
-  .run({ async: false })
+
+await suite.runAndPrintResults()

--- a/bench/parse-int.mjs
+++ b/bench/parse-int.mjs
@@ -15,4 +15,5 @@ suite
   .add('Using + - big number (10 len)', function () {
     ;+'9999999999'
   })
-  .run({ async: false })
+
+await suite.runAndPrintResults()

--- a/bench/possible-undefined-function.mjs
+++ b/bench/possible-undefined-function.mjs
@@ -13,4 +13,5 @@ suite
     const emptyObject = Object.create({})
     emptyObject.undefinedFunction?.()
   })
-  .run({ async: false })
+
+await suite.runAndPrintResults()

--- a/bench/private-property.mjs
+++ b/bench/private-property.mjs
@@ -132,4 +132,5 @@ suite
     b.increaseSize()
     b.dimension
   })
-  .run({ async: true })
+
+await suite.runAndPrintResults()

--- a/bench/property-access-transition.mjs
+++ b/bench/property-access-transition.mjs
@@ -56,4 +56,5 @@ suite
     const obj = new Klass()
     console.assert(obj.d)
   })
-  .run({ async: false })
+
+await suite.runAndPrintResults()

--- a/bench/property-getter-access.mjs
+++ b/bench/property-getter-access.mjs
@@ -156,4 +156,5 @@ suite
   .add('DefineProperties (getter & enumerable=false & configurable=false)', function () {
     const v = definePropertiesEnumerableFalseAndConfigFalseObj.test
   })
-  .run({ async: false })
+
+await suite.runAndPrintResults()

--- a/bench/property-setter-access.mjs
+++ b/bench/property-setter-access.mjs
@@ -173,4 +173,5 @@ suite
   .add('DefineProperties (setter & enumerable=false & configurable=false)', function () {
     definePropertiesEnumerableFalseAndConfigFalseObj.test = 'Hello'
   })
-  .run({ async: false })
+
+await suite.runAndPrintResults()

--- a/bench/replace-vs-replaceall-comparison.mjs
+++ b/bench/replace-vs-replaceall-comparison.mjs
@@ -18,4 +18,5 @@ suite
     const text = '1+2+3+4+5+6+7+8+9'
     const replaced = text.replaceAll(/\+/g, ' ')
   })
-  .run({ async: false })
+
+await suite.runAndPrintResults()

--- a/bench/shallow-copy.mjs
+++ b/bench/shallow-copy.mjs
@@ -98,4 +98,5 @@ suite
       { newProp: true },
     )
   })
-  .run({ async: false })
+
+await suite.runAndPrintResults()

--- a/bench/sort-map.mjs
+++ b/bench/sort-map.mjs
@@ -20,4 +20,5 @@ suite
   .add('Sort using localeCompare', function () {
     new Map([...map].sort((a, b) => String(a[0]).localeCompare(b[0])))
   })
-  .run({ async: false })
+
+await suite.runAndPrintResults()

--- a/bench/spread-vs-object-assign.mjs
+++ b/bench/spread-vs-object-assign.mjs
@@ -95,4 +95,5 @@ suite
   .add('{ ...smallObject, ...anotherSmallObject }', function () {
     const nextObject = { ...smallObject, ...anotherSmallObject }
   })
-  .run({ async: false })
+
+await suite.runAndPrintResults()

--- a/bench/stream-readable.mjs
+++ b/bench/stream-readable.mjs
@@ -52,4 +52,5 @@ suite
       }
     },
   })
-  .run()
+
+await suite.runAndPrintResults()

--- a/bench/stream-writable.mjs
+++ b/bench/stream-writable.mjs
@@ -34,4 +34,5 @@ suite
       ++i
     }
   })
-  .run()
+
+await suite.runAndPrintResults()

--- a/bench/string-concat.mjs
+++ b/bench/string-concat.mjs
@@ -16,4 +16,5 @@ suite
   .add('Using array.join', function () {
     ;[k, o, l].join('-')
   })
-  .run()
+
+await suite.runAndPrintResults()

--- a/bench/string-endsWith.mjs
+++ b/bench/string-endsWith.mjs
@@ -41,4 +41,5 @@ suite
     longString.slice(-comparison2.length) === comparison2
     }
 )
-.run({ async: false })
+
+await suite.runAndPrintResults()

--- a/bench/string-searching.mjs
+++ b/bench/string-searching.mjs
@@ -24,4 +24,5 @@ suite
   .add('Using new RegExp.test with cached regex pattern', function () {
     new RegExp(regex).test(text)
   })
-  .run()
+
+await suite.runAndPrintResults()

--- a/bench/string-startsWith.mjs
+++ b/bench/string-startsWith.mjs
@@ -40,4 +40,5 @@ suite
     longString.slice(0, comparison2.length) === comparison2
     }
 )
-.run({ async: false })
+
+await suite.runAndPrintResults()

--- a/bench/super-vs-this.mjs
+++ b/bench/super-vs-this.mjs
@@ -31,4 +31,5 @@ suite
     const cls = new ThisClass()
     const value = cls.bar()
   })
-  .run()
+
+await suite.runAndPrintResults()

--- a/bench/unix-time.mjs
+++ b/bench/unix-time.mjs
@@ -9,4 +9,5 @@ suite
   .add('Date.now()', function () {
     Date.now()
   })
-  .run({ async: false })
+
+await suite.runAndPrintResults()

--- a/bin.mjs
+++ b/bin.mjs
@@ -1,9 +1,9 @@
-const fs = require('node:fs')
-const path = require('node:path')
-const os = require('node:os')
-const { spawnSync } = require('node:child_process')
+import { readdir } from 'node:fs'
+import { join } from 'node:path'
+import { platform, arch, cpus, totalmem } from 'node:os'
+import { spawnSync } from 'node:child_process'
 
-const machineInfo = `${os.platform()} ${os.arch()} | ${os.cpus().length} vCPUs | ${(os.totalmem() / (1024 ** 3)).toFixed(1)}GB Mem`
+const machineInfo = `${platform()} ${arch()} | ${cpus().length} vCPUs | ${(totalmem() / (1024 ** 3)).toFixed(1)}GB Mem`
 
 const writter = process.stdout
 
@@ -14,9 +14,9 @@ writter.write(`\n
 * __Run:__ ${new Date()}
 `)
 
-fs.readdir(path.join(__dirname, './bench'), (_err, files) => {
+readdir(join(import.meta.dirname, './bench'), (_err, files) => {
   for (const file of files) {
-    const out = spawnSync(process.execPath, [path.join(__dirname, './bench', file)]).stdout
+    const out = spawnSync(process.execPath, [join(import.meta.dirname, './bench', file)]).stdout
     writter.write('\n' + out.toString())
   }
   writter.end()

--- a/common.mjs
+++ b/common.mjs
@@ -2,13 +2,13 @@ import { Bench } from 'tinybench'
 import { createTableHeader, H2, taskToMdTable } from './markdown.mjs'
 import { platform, arch, cpus, totalmem } from 'os'
 
-export function printMdHeader(name, tableHeaderColumns = ['name', 'ops/sec', 'samples']) {
+function printMdHeader(name, tableHeaderColumns = ['name', 'ops/sec', 'samples']) {
   const tableHeader = createTableHeader(tableHeaderColumns)
   console.log(H2(name))
   console.log(tableHeader)
 }
 
-function printMdResults(tasks) {
+function printMarkdownResults(tasks) {
   const cycleEvents = []
   for (const task of tasks) {
     if (process.env.CI) {
@@ -33,7 +33,7 @@ function getMachineInfo() {
   }
 }
 
-export function printMarkdownMachineInfo() {
+function printMarkdownMachineInfo() {
   if (!process.env.CI) return
 
   const { platform, arch, cpus, totalMemory } = getMachineInfo()
@@ -53,7 +53,7 @@ export function printMarkdownMachineInfo() {
   writter.write('\n\n')
 }
 
-export function printMarkdownHiddenDetailedInfo(cycleEvents) {
+function printMarkdownHiddenDetailedInfo(cycleEvents) {
   if (!process.env.CI) return
 
   const writter = process.stdout
@@ -72,16 +72,12 @@ export function printMarkdownHiddenDetailedInfo(cycleEvents) {
 Bench.prototype.runAndPrintResults = async function () {
   await this.warmup()
   await this.run()
-  printMdResults(this.tasks)
+  printMarkdownResults(this.tasks)
 }
 
 export function createBenchmarkSuite(name, { tableHeaderColumns = ['name', 'ops/sec', 'samples'] } = {}) {
   const suite = new Bench()
-
+  // TODO: move it to runAndPrintResults
   printMdHeader(name, tableHeaderColumns)
-  // installMarkdownEmitter(suite, name, tableHeaderColumns)
-  // installMarkdownMachineInfo(suite)
-  // installMarkdownHiddenDetailedInfo(suite)
-
   return suite
 }

--- a/markdown.mjs
+++ b/markdown.mjs
@@ -1,6 +1,6 @@
-export function eventToMdTable (event) {
-  const { target } = event
-  return `|${target.name}|${Math.round(target.hz).toLocaleString()}|${target.stats.sample.length}|`
+export function taskToMdTable (task) {
+  const { result } = task
+  return `|${task.name}|${parseInt(result.hz.toString(), 10).toLocaleString()}|${result.samples.length}|`
 }
 
 export function createTableHeader(columns) {


### PR DESCRIPTION
Some personal research indicates `tinybench` provides more consistent results for the workload we use on this repository.