### PR TITLE
CI: Minor fix runner warmer

### DIFF
--- a/.github/workflows/runner_warmer.yml
+++ b/.github/workflows/runner_warmer.yml
@@ -12,7 +12,7 @@ permissions:
   id-token: write
 
 jobs:
-  start_windows_runner:
+  start_runner:
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS Credentials
@@ -34,7 +34,7 @@ jobs:
       - name: Run task to keep the runner active
         run: echo "Keep the runner active"
 
-  stop_windows_runner:
+  stop_runner:
     runs-on: ubuntu-latest
     needs: keep-runner-active
     steps:

--- a/.github/workflows/runner_warmer.yml
+++ b/.github/workflows/runner_warmer.yml
@@ -34,7 +34,17 @@ jobs:
       - name: Run task to keep the runner active
         run: echo "Keep the runner active"
 
-      - name: Stop Runner
+  stop_windows_runner:
+    runs-on: ubuntu-latest
+    needs: keep-runner-active
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-west-2
+          role-to-assume: arn:aws:iam::800406105498:role/RafaelGSS-nodejs-bench-operations
+
+      - name: Start Runner
         uses: nodesource/aws-eco-runner@v1.0.0-beta.3
         with:
           instances_id: '["i-065f0f848eb1615ae"]'


### PR DESCRIPTION
Currently the runner has not permissions to stop himself using the AWS API.
We might want to separate this action in another job.
Other options are:
- Use an UNIX command like `shutdown` to turn off the system
- Configure the AWS credentials on that JOB to be able to turn off the VM instance using the AWS API