### PR TITLE
ci: update github actions

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -75,10 +75,10 @@ jobs:
       fail-fast: true
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Use Node.js v${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -125,7 +125,7 @@ jobs:
           echo "$result" >> $GITHUB_STEP_SUMMARY
 
       - name: Upload Bench Result
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: benchmark-artifacts-${{github.run_id}}
           retention-days: 1
@@ -167,19 +167,19 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
 
       - name: Use Node.js v22.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 22.x
 
       - name: Create temporary report folder
         run: mkdir ./temp-reports
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: benchmark-artifacts-${{github.run_id}}
           path: ./temp-reports

--- a/.github/workflows/check_regressions.yml
+++ b/.github/workflows/check_regressions.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Use Node.js v${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 'v22.x'
 

--- a/.github/workflows/watch_bench.yml
+++ b/.github/workflows/watch_bench.yml
@@ -20,7 +20,7 @@ jobs:
       changes: ${{ steps.changes.outputs.benchmarks }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: 'Detect File Changes'
         uses: dorny/paths-filter@v2


### PR DESCRIPTION
This PR bumps GitHub Actions to their latest major versions. Main change is they are now using Node 20 instead of 16, which was EOL as of April 2022:
   - Changelog for `actions/checkout` can be [found here](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
   - Releases for `actions/setup-node` can be [found here](https://github.com/actions/setup-node/releases)
   - V4 changes for `actions/upload-artifact` can be [found here](https://github.com/actions/upload-artifact?tab=readme-ov-file#v4---whats-new)
   - V4 changes for `actions/download-artifact` can be [found here](https://github.com/actions/download-artifact?tab=readme-ov-file#v4---whats-new)

