### PR TITLE
ci(bench): use github actions instead of custom actions

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -127,41 +127,15 @@ jobs:
       - name: Upload Bench Result
         uses: actions/upload-artifact@v4
         with:
-          name: benchmark-artifacts-${{github.run_id}}
+          name: benchmark-artifacts-${{github.run_id}}-${{ matrix.node-version }}-${{ inputs.bench-file }}
           retention-days: 1
           if-no-files-found: error
           path: ./${{ env.BENCH_REPORT_FILE }}
 
-      ## Write for matrix outputs workaround
-      - uses: cloudposse/github-action-matrix-outputs-write@main
-        id: out
-        with:
-          matrix-step-name: benchmark-${{ inputs.bench-file }}
-          matrix-key: ${{ matrix.node-version }}
-          outputs: |-
-            failure: 'false'
-            result: ${{ env.BENCH_REPORT_FILE }}
-
-  ## Read matrix outputs
-  read:
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    needs: [benchmark]
-
-    steps:
-      - uses: cloudposse/github-action-matrix-outputs-read@main
-        id: read
-        with:
-          matrix-step-name: benchmark-${{ inputs.bench-file }}
-
-    outputs:
-      result: '${{ steps.read.outputs.result }}'
-
   commit:
     runs-on: ubuntu-latest
     continue-on-error: true
-    if: ${{ needs.read.outputs.failure != 'true' }}
-    needs: [read]
+    needs: [benchmark]
 
     permissions:
       contents: write
@@ -181,7 +155,8 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: benchmark-artifacts-${{github.run_id}}
+          pattern: benchmark-artifacts-*
+          merge-multiple: true
           path: ./temp-reports
 
       - name: Write Benchmark Reports


### PR DESCRIPTION
The new action looks easier to do what we wanted: https://github.com/actions/upload-artifact/blob/v4/docs/MIGRATION.md#multiple-uploads-to-the-same-named-artifact