### PR TITLE
feat(metrics): add initialization & memory metrics to benchmark with poop

### DIFF
--- a/.github/workflows/poop-bench.yml
+++ b/.github/workflows/poop-bench.yml
@@ -1,0 +1,190 @@
+name: 'Run Poop Benchmarks'
+
+on:
+  workflow_dispatch:
+    inputs:
+      node-versions:
+        required: true
+        type: string
+        default: '["18.0.0","18.20.7","18.20.8","20.0.0","20.19.0","20.19.1","21.0.0","21.7.2","21.7.3","22.0.0","22.14.0","22.15.0","23.0.0","23.10.0","23.11.0"]'
+        description: 'The Node.js Versions (should be a JSON array)'
+      run-start-stop:
+        required: false
+        type: boolean
+        default: true
+        description: 'When false, starting and stopping the runner machine is skipped'
+  workflow_call:
+    inputs:
+      node-versions:
+        required: true
+        type: string
+        default: '["18.0.0","18.20.0","18.20.4","20.0.0","20.17.0","20.18.0","21.0.0","21.7.3","22.0.0","22.9.0","22.11.0", "23.0.0"]'
+        description: 'The Node.js Versions (should be a JSON array)'
+      run-start-stop:
+        required: false
+        type: boolean
+        default: true
+        description: 'When false, starting and stopping the runner machine is skipped'
+
+permissions:
+  issues: write
+  contents: read
+  id-token: write
+
+jobs:
+  runner-start:
+    if: ${{ inputs.run-start-stop == true }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-west-2
+          role-to-assume: arn:aws:iam::800406105498:role/RafaelGSS-nodejs-bench-operations
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Start Runner
+        uses: nodesource/aws-eco-runner@v1.0.0-beta.3
+        with:
+          instances_id: '["i-065f0f848eb1615ae"]'
+          action: 'start'
+          aws_default_region: 'us-west-2'
+
+  poop-benchmark:
+    continue-on-error: true
+    runs-on: self-hosted
+    # needs: runner-start
+    if: always()
+    strategy:
+      matrix:
+        node-version: ${{ fromJson(inputs.node-versions) }}
+      fail-fast: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js v${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: NPM Install
+        run: npm install
+
+      - name: Download poop binary
+        run: node scripts/download-poop.mjs
+
+      - name: Report Filename
+        run: echo "POOP_REPORT_FILE=poop-report-${{github.run_id}}-${{ matrix.node-version }}.md" >> $GITHUB_ENV
+
+      - name: Run Poop Benchmarks
+        run: node scripts/run-poop-benchmarks.mjs > ./${{ env.POOP_REPORT_FILE }}
+        env:
+          CI: true
+          POOP_BINARY: ./poop
+          POOP_DURATION: '5000'
+
+      - name: Notify on Error
+        if: ${{ failure() }}
+        uses: dacbd/create-issue-action@main
+        with:
+          token: ${{ github.token }}
+          title: Poop benchmark failed on v${{ matrix.node-version }}
+          body: |
+            ### Context
+            [Failed Run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+            [Codebase](https://github.com/${{ github.repository }}/tree/${{ github.sha }})
+            Workflow name - `${{ github.workflow }}`
+            Job -           `${{ github.job }}`
+            status -        `${{ job.status }}`
+          assignees: RafaelGSS
+          labels: bug
+
+      - name: Output Failure
+        if: ${{ failure() }}
+        uses: cloudposse/github-action-matrix-outputs-write@main
+        with:
+          matrix-step-name: poop-benchmark
+          matrix-key: ${{ matrix.node-version }}
+          outputs: |-
+            failure: 'true'
+            result: ''
+
+      - name: Add Job Summary
+        run: |
+          result=$(cat ./${{ env.POOP_REPORT_FILE }})
+          echo "$result" >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload Poop Result
+        uses: actions/upload-artifact@v4
+        with:
+          name: poop-artifacts-${{github.run_id}}-${{ matrix.node-version }}
+          retention-days: 1
+          if-no-files-found: error
+          path: ./${{ env.POOP_REPORT_FILE }}
+
+  commit:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    needs: [poop-benchmark]
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Use Node.js v22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+
+      - name: Create temporary report folder
+        run: mkdir ./temp-reports
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: poop-artifacts-*
+          merge-multiple: true
+          path: ./temp-reports
+
+      - name: Write Poop Reports
+        run: |
+          node scripts/write-poop-results.mjs
+          node scripts/generate-reports.mjs
+
+      - name: Clean temporary report folder
+        run: rm -r ./temp-reports
+
+      - name: Commit and Push Updated Results
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          branch: ${{ github.ref }}
+          commit_message: 'chore(poop): update benchmark results'
+          commit_author: Github Actions <actions@github.com>
+
+  ## Stop Runner
+  runner-stop:
+    if: ${{ inputs.run-start-stop == true }}
+    runs-on: ubuntu-latest
+    needs: [poop-benchmark]
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Stop Runner
+        uses: nodesource/aws-eco-runner@v1.0.0-beta.3
+        with:
+          instances_id: '["i-065f0f848eb1615ae"]'
+          action: 'stop'
+          aws_default_region: 'us-west-2'

--- a/.github/workflows/run_all.yml
+++ b/.github/workflows/run_all.yml
@@ -8,7 +8,7 @@ on:
       node-versions:
         required: true
         type: string
-        default: '["20.0.0","20.19.4","20.19.5","22.0.0","22.15.1","22.17.1","24.0.0","24.4.1","25.0.0"]'
+        default: '["20.0.0","20.19.6","20.20.1","22.0.0","22.21.1","22.22.1","24.0.0","24.11.1","24.13.1","25.0.0","25.2.1","25.6.1"]'
         description: 'The Node.js Versions (should be a JSON array)'
 
 permissions:
@@ -341,10 +341,18 @@ jobs:
       node-versions: ${{ inputs.node-versions }}
       run-start-stop: false
 
+  poop_benchmarks:
+    needs: unix-time
+    name: Running "poop benchmarks"
+    uses: ./.github/workflows/poop-bench.yml
+    with:
+      node-versions: ${{ inputs.node-versions }}
+      run-start-stop: false
+
   ## Stop Runner
   runner-stop:
     runs-on: ubuntu-latest
-    needs: [unix-time]
+    needs: [poop_benchmarks]
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 tags
 package-lock.json
 bench-result.md
+/poop

--- a/fixtures/empty.js
+++ b/fixtures/empty.js
@@ -1,0 +1,2 @@
+// do nothing, even console.log can affect the benchmarks
+const a = 1;

--- a/fixtures/poop-commands.json
+++ b/fixtures/poop-commands.json
@@ -1,0 +1,10 @@
+[
+  {
+    "name": "node version",
+    "command": ["node", "-v"]
+  },
+  {
+    "name": "node run empty script",
+    "command": ["node", "./fixtures/empty.js"]
+  }
+]

--- a/scripts/check-regression.mjs
+++ b/scripts/check-regression.mjs
@@ -1,6 +1,9 @@
 import fs from 'node:fs/promises';
 import { resolve } from 'node:path';
 
+const ARBITRARY_THRESHOLD = 0.20;
+const ARBITRARY_THRESHOLD_POOP = 0.10;
+
 async function parseMD(path) {
   const content = await fs.readFile(path, 'utf-8');
   const strData = content.match(/<!--([\s\S]*?)-->/);
@@ -11,16 +14,85 @@ async function parseMD(path) {
   return JSON.parse(strData[1].trim());
 }
 
-async function readResult (path) {
+async function readResult(path) {
   const dir = await fs.opendir(path);
   const results = {};
   for await (const file of dir) {
     if (file.isFile()) {
-      const filePath = resolve(file.path, file.name);
+      const filePath = resolve(file.parentPath || file.path, file.name);
       results[file.name] = await parseMD(filePath);
     }
   }
   return results;
+}
+
+function parseMetricValue(value) {
+  /**
+   * Convert poop metric values to numbers for comparison
+   * Examples: "2.64ms" → 0.00264, "17.0MB" → 17825792, "4.24M" → 4240000
+   */
+  const units = {
+    'ns': 1e-9, 'us': 1e-6, 'ms': 1e-3, 's': 1,
+    'B': 1, 'KB': 1024, 'MB': 1024 ** 2, 'GB': 1024 ** 3,
+    'K': 1e3, 'M': 1e6, 'G': 1e9
+  };
+
+  const match = value.match(/^([\d.]+)\s*(\w*)$/);
+  if (!match) return parseFloat(value);
+
+  const [, num, unit] = match;
+  const multiplier = units[unit] || 1;
+  return parseFloat(num) * multiplier;
+}
+
+/**
+ * Check for regressions in poop metrics (wall_time, peak_rss, cpu_cycles, etc.)
+ * For poop metrics, lower values are better (unlike opsSec where higher is better)
+ */
+async function checkPoopRegression(aResult, bResult, bench) {
+  const aBench = aResult[bench].benchmarks;
+  const bBench = bResult[bench].benchmarks;
+
+  for (let i = 0; i < aBench.length; ++i) {
+    const aBenchResult = aBench[i];
+    const bBenchResult = bBench[i];
+
+    if (aBenchResult.command !== bBenchResult.command) {
+      console.warn(`Wrong benchmark comparison - ${aBenchResult.command} !== ${bBenchResult.command}. Skipping...`);
+      continue;
+    }
+
+    const metricNames = Object.keys(aBenchResult.metrics);
+    for (const metricName of metricNames) {
+      const aMetric = aBenchResult.metrics[metricName];
+      const bMetric = bBenchResult.metrics[metricName];
+
+      if (!aMetric || !bMetric) continue;
+
+      const aMean = parseMetricValue(aMetric.mean);
+      const bMean = parseMetricValue(bMetric.mean);
+
+      if (aMean === bMean) {
+        console.info(`${bench} - ${aBenchResult.command}#${metricName} are equals`);
+        continue;
+      }
+
+      const percent = ((bMean - aMean) / aMean * 100).toFixed(2);
+
+      // For poop metrics, lower is better (regression if value increases)
+      if (bMean > aMean) {
+        const threshold = aMean + (aMean * ARBITRARY_THRESHOLD_POOP);
+        if (bMean > threshold) {
+          console.warn(`😱 - ${bench}#${aBenchResult.command}#${metricName} | +${percent}% (${aMetric.mean} → ${bMetric.mean})`);
+        }
+      } else {
+        const threshold = aMean - (aMean * ARBITRARY_THRESHOLD_POOP);
+        if (bMean < threshold) {
+          console.warn(`😁 - ${bench}#${aBenchResult.command}#${metricName} | ${percent}% (${aMetric.mean} → ${bMetric.mean})`);
+        }
+      }
+    }
+  }
 }
 
 async function checkRegression(aResult, bResult) {
@@ -38,6 +110,12 @@ async function checkRegression(aResult, bResult) {
     if (!aResult[bench].benchmarks || !bResult[bench].benchmarks) {
       console.warn(`No benchmarks field for ${bench}`);
       throw new Error('Unexpected behavior');
+    }
+
+    // Check if this is a poop metrics benchmark
+    if (aResult[bench].type === 'poop-metrics') {
+      await checkPoopRegression(aResult, bResult, bench);
+      continue;
     }
 
     const aBench = aResult[bench].benchmarks;
@@ -60,14 +138,12 @@ async function checkRegression(aResult, bResult) {
       const percent = ((bOpsSec - aOpsSec) / aOpsSec * 100).toFixed(2);
       // regression
       if (aOpsSec - bOpsSec > 0) {
-        // arbitrary threshold
-        const threshold = aOpsSec - (aOpsSec * 0.20);
+        const threshold = aOpsSec - (aOpsSec * ARBITRARY_THRESHOLD);
         if (bOpsSec < threshold) {
           console.warn(`😱 - ${bench}#${aBenchResult.name} | ${percent}%`);
         }
       } else {
-        // arbitrary threshold
-        const threshold = aOpsSec + (aOpsSec * 0.20);
+        const threshold = aOpsSec + (aOpsSec * ARBITRARY_THRESHOLD);
         if (bOpsSec > threshold) {
           console.warn(`😁 - ${bench}#${aBenchResult.name} | ${percent}%`);
         }
@@ -76,7 +152,7 @@ async function checkRegression(aResult, bResult) {
   }
 }
 
-async function main (versions, majorOnly) {
+async function main(versions, majorOnly) {
   let previous;
   let previousName;
 
@@ -91,7 +167,7 @@ async function main (versions, majorOnly) {
     }
     for await (const dirent of dir) {
       if (dirent.isDirectory()) {
-        const content = await readResult(resolve(dirent.path, dirent.name));
+        const content = await readResult(resolve(dirent.parentPath || dirent.path, dirent.name));
         if (!previous) {
           previous = content;
           previousName = dirent.name;

--- a/scripts/download-poop.mjs
+++ b/scripts/download-poop.mjs
@@ -1,0 +1,31 @@
+import { writeFile, chmod } from 'node:fs/promises';
+import { join } from 'node:path';
+import { arch as osArch, platform as osPlatform } from 'node:os';
+import { rootFolder } from './utils.mjs';
+
+const POOP_REPO = 'andrewrk/poop';
+const OUTPUT_PATH = join(rootFolder, 'poop');
+
+function getPoopArchName() {
+  const archMap = { 'x64': 'x86_64', 'ia32': 'x86', 'arm64': 'aarch64', 'riscv64': 'riscv64' };
+  return archMap[osArch()] || osArch();
+}
+
+async function downloadPoop() {
+  if (osPlatform() !== 'linux') throw new Error(`poop only supports Linux`);
+  
+  const assetName = `${getPoopArchName()}-linux-poop`;
+  console.log(`Fetching latest poop release...`);
+  
+  const release = await fetch(`https://api.github.com/repos/${POOP_REPO}/releases/latest`).then(r => r.json());
+  const asset = release.assets.find(a => a.name === assetName);
+  if (!asset) throw new Error(`No binary for ${assetName}`);
+  
+  console.log(`Downloading ${asset.name} from ${release.tag_name}...`);
+  const buffer = await fetch(asset.browser_download_url).then(r => r.arrayBuffer());
+  await writeFile(OUTPUT_PATH, Buffer.from(buffer));
+  await chmod(OUTPUT_PATH, 0o755);
+  console.log(`Downloaded poop to ${OUTPUT_PATH}`);
+}
+
+downloadPoop().catch(err => { console.error(err); process.exit(1); });

--- a/scripts/generate-run-all.mjs
+++ b/scripts/generate-run-all.mjs
@@ -30,6 +30,16 @@ const benchJobs = allBenches.map((benchFile, index, array) => {
 `;
 });
 
+const poopJob = `
+  poop_benchmarks:
+    needs: ${lastJobName}
+    name: Running "poop benchmarks"
+    uses: ./.github/workflows/poop-bench.yml
+    with:
+      node-versions: \${{ inputs.node-versions }}
+      run-start-stop: false
+`;
+
 const MAJORS = [20, 22, 24, 25];
 const nodeVersions = []
 const allVersions = await nv('all');
@@ -80,11 +90,11 @@ jobs:
           instances_id: '["i-065f0f848eb1615ae"]'
           action: 'start'
           aws_default_region: 'us-west-2'
-  ${benchJobs.join('')}
+  ${benchJobs.join('')}${poopJob}
   ## Stop Runner
   runner-stop:
     runs-on: ubuntu-latest
-    needs: [${lastJobName}]
+    needs: [poop_benchmarks]
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/scripts/poop-parser.mjs
+++ b/scripts/poop-parser.mjs
@@ -1,0 +1,56 @@
+export function parsePoop(output) {
+  const lines = output.trim().split('\n');
+  const results = [];
+  let currentBenchmark = null;
+  
+  for (const line of lines) {
+    const benchmarkMatch = line.match(/^Benchmark \d+ \((\d+) runs?\): (.+)$/);
+    if (benchmarkMatch) {
+      if (currentBenchmark) results.push(currentBenchmark);
+      currentBenchmark = {
+        runs: parseInt(benchmarkMatch[1], 10),
+        command: benchmarkMatch[2],
+        metrics: {}
+      };
+      continue;
+    }
+    
+    const metricMatch = line.match(
+      /^\s+(\w+)\s+([\d.]+\s*\w*)\s+[±+-]+\s+([\d.]+\s*\w*)\s+([\d.]+\s*\w*)\s+[…\.]+\s+([\d.]+\s*\w*)\s+(\d+)\s*\(\s*(\d+)%\)/
+    );
+    
+    if (metricMatch && currentBenchmark) {
+      const [, name, mean, std, min, max, outliers, outlierPercent] = metricMatch;
+      currentBenchmark.metrics[name.trim()] = {
+        mean: mean.trim(), std: std.trim(), min: min.trim(), max: max.trim(),
+        outliers: parseInt(outliers, 10), outlierPercent: parseInt(outlierPercent, 10)
+      };
+    }
+  }
+  if (currentBenchmark) results.push(currentBenchmark);
+  return results;
+}
+
+export function poopToMarkdown(results, includeJson = false) {
+  let markdown = '## Metrics\n\n';
+  for (const result of results) {
+    markdown += `### \`${result.command}\`\n\n`;
+    markdown += `> Runs: ${result.runs}\n\n`;
+    markdown += '| metric | mean | std | min | max | outliers (%) |\n';
+    markdown += '|--------|------|-----|-----|-----|-------------|\n';
+    for (const [metricName, data] of Object.entries(result.metrics)) {
+      markdown += `| ${metricName} | ${data.mean} | ${data.std} | ${data.min} | ${data.max} | ${data.outliers} (${data.outlierPercent}%) |\n`;
+    }
+    markdown += '\n';
+  }
+  
+  if (includeJson) {
+    markdown += `<!--\n${JSON.stringify({ type: 'poop-metrics', benchmarks: results })}\n-->\n`;
+  }
+  
+  return markdown;
+}
+
+export function poopToHiddenJson(results) {
+  return `<!--\n${JSON.stringify({ type: 'poop-metrics', benchmarks: results })}\n-->`;
+}

--- a/scripts/run-poop-benchmarks.mjs
+++ b/scripts/run-poop-benchmarks.mjs
@@ -1,0 +1,39 @@
+import { readFile } from 'node:fs/promises';
+import { execSync } from 'node:child_process';
+import { join } from 'node:path';
+import { platform, arch, cpus, totalmem } from 'node:os';
+import { parsePoop, poopToMarkdown } from './poop-parser.mjs';
+import { rootFolder } from './utils.mjs';
+
+const POOP_BINARY = process.env.POOP_BINARY || 'poop';
+const POOP_DURATION = process.env.POOP_DURATION || '5000';
+
+async function main() {
+  const configPath = join(rootFolder, 'fixtures', 'poop-commands.json');
+  const commands = JSON.parse(await readFile(configPath, 'utf-8'));
+  const allCommands = commands.flatMap(cmd => `'${cmd.command.join(' ')}'`);
+  const poopArgs = ['-d', POOP_DURATION, ...allCommands];
+  
+  console.error(`Running: ${POOP_BINARY} ${poopArgs.join(' ')}`);
+  
+  let output;
+  try {
+    output = execSync(`${POOP_BINARY} ${poopArgs.join(' ')}`, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] });
+  } catch (error) {
+    output = error.stdout || '';
+    if (!output) throw error;
+  }
+  
+  const results = parsePoop(output);
+  const includeJson = !!process.env.CI;
+  let markdown = poopToMarkdown(results, includeJson);
+  
+  const machineInfo = `${platform()} ${arch()} | ${cpus().length} vCPUs | ${(totalmem() / 1024 ** 3).toFixed(1)}GB Mem`;
+  markdown += '\n<details>\n<summary>Environment</summary>\n\n';
+  markdown += `* __Machine:__ ${machineInfo}\n* __Run:__ ${new Date()}\n* __Node:__ \`${process.version}\`\n`;
+  markdown += '</details>\n';
+  
+  console.log(markdown);
+}
+
+main().catch(err => { console.error(err); process.exit(1); });

--- a/scripts/write-poop-results.mjs
+++ b/scripts/write-poop-results.mjs
@@ -1,0 +1,53 @@
+import { mkdir, rename } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { existAsync, rootFolder } from './utils.mjs';
+import { readdir } from 'node:fs/promises';
+
+const artifactsDir = './temp-reports';
+
+/**
+ * Get all poop report files from the temp-reports directory
+ * Parse the node version from the filename format: poop-report-runid-nodeversion.md
+ * @returns {Promise<{ [nodeVersion: string]: string }>} Map of node version to report filename
+ */
+async function getPoopFiles() {
+  const files = await readdir(artifactsDir);
+  const poopFiles = {};
+  
+  for (const file of files) {
+    // Only process poop report files
+    if (file.startsWith('poop-report-')) {
+      // Extract the node version from the filename pattern: poop-report-runid-nodeversion.md
+      const parts = file.split('-');
+      // The node version should be the last part before .md (index 3)
+      if (parts.length >= 4) {
+        const nodeVersion = parts[3].replace('.md', '');
+        poopFiles[nodeVersion] = file;
+      }
+    }
+  }
+  
+  return poopFiles;
+}
+
+async function processPoopReports() {
+  const poopFiles = await getPoopFiles();
+  
+  for (const nodeVersion of Object.keys(poopFiles)) {
+    const reportFilepath = resolve(artifactsDir, poopFiles[nodeVersion]);
+    
+    const normalizedNodeVersion = nodeVersion.replace(/\./g, '_');
+    const major = normalizedNodeVersion.split('_')[0];
+    const outputFolder = resolve(rootFolder, `./v${major}/v${normalizedNodeVersion}`);
+    
+    if (!await existAsync(outputFolder)) {
+      await mkdir(outputFolder, { recursive: true });
+    }
+    
+    const outputFilepath = resolve(outputFolder, 'metrics.md');
+    await rename(reportFilepath, outputFilepath);
+    console.log(`Moved poop report for Node.js v${nodeVersion} to ${outputFilepath}`);
+  }
+}
+
+processPoopReports().catch(console.error);


### PR DESCRIPTION
Fixes #332 

Instead of `hyperfine`, I choose the https://github.com/andrewrk/poop because of the support to collect memory & many other metrics.

Changes:
- Add new benchmark yml to run the poop benchmark for each node version
- Add support for regression to compare the results

The result will be a new file `metrics.md` with the commands we define at `fixtures/poop-commands.json`.

<details>
<summary>Example of Markdown of the result of poop</summary>
```md
## Metrics

### `node -v`

> Runs: 1962

| metric | mean | std | min | max | outliers (%) |
|--------|------|-----|-----|-----|-------------|
| wall_time | 2.51ms | 314us | 2.23ms | 5.50ms | 92 (5%) |
| peak_rss | 17.0MB | 186KB | 16.1MB | 17.3MB | 113 (6%) |
| cpu_cycles | 4.27M | 482K | 4.05M | 10.7M | 289 (15%) |
| instructions | 7.67M | 40.9 | 7.67M | 7.67M | 17 (1%) |
| cache_references | 209K | 6.32K | 172K | 291K | 102 (5%) |
| cache_misses | 50.3K | 1.50K | 44.3K | 58.2K | 31 (2%) |
| branch_misses | 50.4K | 675 | 47.1K | 61.1K | 49 (2%) |

### `node ./fixtures/empty.js`

> Runs: 287

| metric | mean | std | min | max | outliers (%) |
|--------|------|-----|-----|-----|-------------|
| wall_time | 17.4ms | 1.45ms | 14.6ms | 22.5ms | 5 (2%) |
| peak_rss | 47.4MB | 528KB | 44.6MB | 48.0MB | 13 (5%) |
| cpu_cycles | 48.9M | 4.72M | 39.7M | 65.5M | 4 (1%) |
| instructions | 89.8M | 5.52M | 80.8M | 114M | 7 (2%) |
| cache_references | 1.86M | 29.6K | 1.71M | 1.97M | 15 (5%) |
| cache_misses | 387K | 9.27K | 363K | 434K | 13 (5%) |
| branch_misses | 567K | 108K | 390K | 1.05M | 8 (3%) |

<!--
{"type":"poop-metrics","benchmarks":[{"runs":1962,"command":"node -v","metrics":{"wall_time":{"mean":"2.51ms","std":"314us","min":"2.23ms","max":"5.50ms","outliers":92,"outlierPercent":5},"peak_rss":{"mean":"17.0MB","std":"186KB","min":"16.1MB","max":"17.3MB","outliers":113,"outlierPercent":6},"cpu_cycles":{"mean":"4.27M","std":"482K","min":"4.05M","max":"10.7M","outliers":289,"outlierPercent":15},"instructions":{"mean":"7.67M","std":"40.9","min":"7.67M","max":"7.67M","outliers":17,"outlierPercent":1},"cache_references":{"mean":"209K","std":"6.32K","min":"172K","max":"291K","outliers":102,"outlierPercent":5},"cache_misses":{"mean":"50.3K","std":"1.50K","min":"44.3K","max":"58.2K","outliers":31,"outlierPercent":2},"branch_misses":{"mean":"50.4K","std":"675","min":"47.1K","max":"61.1K","outliers":49,"outlierPercent":2}}},{"runs":287,"command":"node ./fixtures/empty.js","metrics":{"wall_time":{"mean":"17.4ms","std":"1.45ms","min":"14.6ms","max":"22.5ms","outliers":5,"outlierPercent":2},"peak_rss":{"mean":"47.4MB","std":"528KB","min":"44.6MB","max":"48.0MB","outliers":13,"outlierPercent":5},"cpu_cycles":{"mean":"48.9M","std":"4.72M","min":"39.7M","max":"65.5M","outliers":4,"outlierPercent":1},"instructions":{"mean":"89.8M","std":"5.52M","min":"80.8M","max":"114M","outliers":7,"outlierPercent":2},"cache_references":{"mean":"1.86M","std":"29.6K","min":"1.71M","max":"1.97M","outliers":15,"outlierPercent":5},"cache_misses":{"mean":"387K","std":"9.27K","min":"363K","max":"434K","outliers":13,"outlierPercent":5},"branch_misses":{"mean":"567K","std":"108K","min":"390K","max":"1.05M","outliers":8,"outlierPercent":3}}}]}
-->

<details>
<summary>Environment</summary>

* __Machine:__ linux x64 | 32 vCPUs | 62.7GB Mem
* __Run:__ Sun Mar 08 2026 13:30:55 GMT-0300 (Brasilia Standard Time)
* __Node:__ `v25.7.0`
</details>
```
</details>